### PR TITLE
feat(models): define User, Card, Transaction domain types and DTOs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@
 //! entrypoint (`main.rs`) and by integration tests.
 
 pub mod error;
+pub mod models;

--- a/src/models/card.rs
+++ b/src/models/card.rs
@@ -1,0 +1,130 @@
+//! Card domain type, request DTOs, and response DTOs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Newtype wrapper for card IDs to prevent accidental mixing with other ID types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CardId(pub Uuid);
+
+impl std::fmt::Display for CardId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Core card domain type as stored in the database.
+///
+/// All card data is encrypted client-side; the server stores only
+/// opaque blobs and never inspects the plaintext content.
+#[derive(Debug, Clone)]
+pub struct Card {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request DTO for creating a card.
+///
+/// Encrypted fields are base64-encoded strings produced by the client's
+/// AES-256-GCM encryption before transmission.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateCard {
+    pub encrypted_data: String,
+    pub iv: String,
+    pub auth_tag: String,
+}
+
+/// Public-facing card response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CardResponse {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub encrypted_data: String,
+    pub iv: String,
+    pub auth_tag: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_card_id_serializes_as_uuid_string() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let card_id = CardId(id);
+        let serialized = serde_json::to_value(&card_id).unwrap();
+        assert_eq!(serialized, json!("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_card_id_deserializes_from_uuid_string() {
+        let json = json!("550e8400-e29b-41d4-a716-446655440000");
+        let card_id: CardId = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            card_id.0,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_card_id_display_shows_uuid() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_eq!(
+            format!("{}", CardId(id)),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn test_create_card_deserializes_with_snake_case_fields() {
+        let json = json!({
+            "encrypted_data": "base64data",
+            "iv": "base64iv",
+            "auth_tag": "base64tag"
+        });
+        let dto: CreateCard = serde_json::from_value(json).unwrap();
+        assert_eq!(dto.encrypted_data, "base64data");
+        assert_eq!(dto.iv, "base64iv");
+        assert_eq!(dto.auth_tag, "base64tag");
+    }
+
+    #[test]
+    fn test_card_response_serializes_with_snake_case_fields() {
+        let resp = CardResponse {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            encrypted_data: "base64data".to_string(),
+            iv: "base64iv".to_string(),
+            auth_tag: "base64tag".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+        };
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["encrypted_data"], "base64data");
+        assert_eq!(value["iv"], "base64iv");
+        assert_eq!(value["auth_tag"], "base64tag");
+    }
+
+    #[test]
+    fn test_card_struct_derives_debug_and_clone() {
+        let card = Card {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            encrypted_data: vec![1, 2, 3],
+            iv: vec![4, 5, 6],
+            auth_tag: vec![7, 8, 9],
+            created_at: Utc::now(),
+        };
+        let cloned = card.clone();
+        assert_eq!(card.id, cloned.id);
+        let _ = format!("{card:?}");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,9 @@
+//! Domain models, request DTOs, and response DTOs for all core types.
+
+pub mod card;
+pub mod transaction;
+pub mod user;
+
+pub use card::{Card, CardId, CardResponse, CreateCard};
+pub use transaction::{CreateTransaction, Transaction, TransactionId, TransactionResponse};
+pub use user::{CreateUser, User, UserId, UserResponse};

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,0 +1,146 @@
+//! Transaction domain type, request DTOs, and response DTOs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Newtype wrapper for transaction IDs to prevent accidental mixing with other ID types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TransactionId(pub Uuid);
+
+impl std::fmt::Display for TransactionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Core transaction domain type as stored in the database.
+///
+/// All financial data is encrypted client-side. The only temporal
+/// metadata stored in plaintext is `timestamp_bucket` ("YYYY-MM"),
+/// which allows filtering without exposing exact timestamps.
+#[derive(Debug, Clone)]
+pub struct Transaction {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub card_id: Uuid,
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+    /// Month bucket in "YYYY-MM" format — the only non-encrypted temporal metadata.
+    pub timestamp_bucket: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request DTO for creating a transaction.
+///
+/// Encrypted fields are base64-encoded strings produced by the client's
+/// AES-256-GCM encryption before transmission.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateTransaction {
+    pub card_id: Uuid,
+    pub encrypted_data: String,
+    pub iv: String,
+    pub auth_tag: String,
+    /// Month bucket in "YYYY-MM" format.
+    pub timestamp_bucket: String,
+}
+
+/// Public-facing transaction response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TransactionResponse {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub card_id: Uuid,
+    pub encrypted_data: String,
+    pub iv: String,
+    pub auth_tag: String,
+    pub timestamp_bucket: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_transaction_id_serializes_as_uuid_string() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let tx_id = TransactionId(id);
+        let serialized = serde_json::to_value(&tx_id).unwrap();
+        assert_eq!(serialized, json!("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_transaction_id_deserializes_from_uuid_string() {
+        let json = json!("550e8400-e29b-41d4-a716-446655440000");
+        let tx_id: TransactionId = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            tx_id.0,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_transaction_id_display_shows_uuid() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_eq!(
+            format!("{}", TransactionId(id)),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn test_create_transaction_deserializes_with_snake_case_fields() {
+        let card_id = Uuid::new_v4();
+        let json = json!({
+            "card_id": card_id,
+            "encrypted_data": "base64data",
+            "iv": "base64iv",
+            "auth_tag": "base64tag",
+            "timestamp_bucket": "2025-03"
+        });
+        let dto: CreateTransaction = serde_json::from_value(json).unwrap();
+        assert_eq!(dto.card_id, card_id);
+        assert_eq!(dto.encrypted_data, "base64data");
+        assert_eq!(dto.timestamp_bucket, "2025-03");
+    }
+
+    #[test]
+    fn test_transaction_response_serializes_with_snake_case_fields() {
+        let resp = TransactionResponse {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            card_id: Uuid::new_v4(),
+            encrypted_data: "base64data".to_string(),
+            iv: "base64iv".to_string(),
+            auth_tag: "base64tag".to_string(),
+            timestamp_bucket: "2025-03".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+        };
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["timestamp_bucket"], "2025-03");
+        assert_eq!(value["encrypted_data"], "base64data");
+        assert!(value.get("password_hash").is_none());
+    }
+
+    #[test]
+    fn test_transaction_struct_derives_debug_and_clone() {
+        let tx = Transaction {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            card_id: Uuid::new_v4(),
+            encrypted_data: vec![1, 2],
+            iv: vec![3, 4],
+            auth_tag: vec![5, 6],
+            timestamp_bucket: "2025-03".to_string(),
+            created_at: Utc::now(),
+        };
+        let cloned = tx.clone();
+        assert_eq!(tx.timestamp_bucket, cloned.timestamp_bucket);
+        let _ = format!("{tx:?}");
+    }
+}

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,0 +1,131 @@
+//! User domain type, request DTOs, and response DTOs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Newtype wrapper for user IDs to prevent accidental mixing with other ID types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UserId(pub Uuid);
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Core user domain type as stored in the database.
+///
+/// Sensitive fields (`wrapped_dek`, `dek_salt`) are encrypted blobs
+/// and are never exposed outside the authenticated owner's session.
+#[derive(Debug, Clone)]
+pub struct User {
+    pub id: Uuid,
+    pub email: String,
+    pub password_hash: String,
+    pub wrapped_dek: Vec<u8>,
+    pub dek_salt: Vec<u8>,
+    pub dek_params: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request DTO for user registration.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateUser {
+    pub email: String,
+    pub password: String,
+    pub wrapped_dek: String,
+    pub dek_salt: String,
+    pub dek_params: String,
+}
+
+/// Public-facing user response, omitting all sensitive fields.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UserResponse {
+    pub id: Uuid,
+    pub email: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_user_id_serializes_as_uuid_string() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let user_id = UserId(id);
+        let serialized = serde_json::to_value(&user_id).unwrap();
+        assert_eq!(serialized, json!("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_user_id_deserializes_from_uuid_string() {
+        let json = json!("550e8400-e29b-41d4-a716-446655440000");
+        let user_id: UserId = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            user_id.0,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_user_id_display_shows_uuid() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let user_id = UserId(id);
+        assert_eq!(format!("{user_id}"), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn test_create_user_deserializes_with_snake_case_fields() {
+        let json = json!({
+            "email": "test@example.com",
+            "password": "secret",
+            "wrapped_dek": "base64encryptedkey",
+            "dek_salt": "base64salt",
+            "dek_params": "{\"m\":65536}"
+        });
+        let dto: CreateUser = serde_json::from_value(json).unwrap();
+        assert_eq!(dto.email, "test@example.com");
+        assert_eq!(dto.password, "secret");
+        assert_eq!(dto.wrapped_dek, "base64encryptedkey");
+        assert_eq!(dto.dek_salt, "base64salt");
+        assert_eq!(dto.dek_params, "{\"m\":65536}");
+    }
+
+    #[test]
+    fn test_user_response_serializes_with_snake_case_fields() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let resp = UserResponse {
+            id,
+            email: "test@example.com".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+        };
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(value["email"], "test@example.com");
+        assert_eq!(value["id"], "550e8400-e29b-41d4-a716-446655440000");
+        assert!(
+            value.get("password_hash").is_none(),
+            "password_hash must not be exposed"
+        );
+    }
+
+    #[test]
+    fn test_user_struct_derives_debug_and_clone() {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: "a@b.com".to_string(),
+            password_hash: "hash".to_string(),
+            wrapped_dek: vec![1, 2, 3],
+            dek_salt: vec![4, 5, 6],
+            dek_params: "{}".to_string(),
+            created_at: Utc::now(),
+        };
+        let cloned = user.clone();
+        assert_eq!(user.email, cloned.email);
+        let _ = format!("{user:?}");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `src/models/user.rs`: `UserId` newtype, `User` domain struct, `CreateUser` and `UserResponse` DTOs
- Add `src/models/card.rs`: `CardId` newtype, `Card` domain struct, `CreateCard` and `CardResponse` DTOs
- Add `src/models/transaction.rs`: `TransactionId` newtype, `Transaction` domain struct, `CreateTransaction` and `TransactionResponse` DTOs
- Move models into `lib.rs` so `pub` items aren't flagged as dead_code before repositories/handlers exist

## Acceptance Criteria
- [x] `User` struct with fields: id, email, password_hash, wrapped_dek, dek_salt, dek_params, created_at
- [x] `Card` struct with: id, user_id, encrypted_data, iv, auth_tag, created_at
- [x] `Transaction` struct with: id, user_id, card_id, encrypted_data, iv, auth_tag, timestamp_bucket, created_at
- [x] `CreateUser`, `CreateCard`, `CreateTransaction` request DTOs with `Deserialize`
- [x] Response DTOs with `Serialize`
- [x] Newtype wrappers: `UserId(Uuid)`, `CardId(Uuid)`, `TransactionId(Uuid)`
- [x] All structs derive `Debug`; API structs use `#[serde(rename_all = "snake_case")]`
- [x] 18 unit tests for serialization/deserialization

## Test plan
- [x] `cargo test` — 23 tests passing (18 new + 5 existing)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied

Resolves #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)