### PR TITLE
feat(server): axum hello-world with GET /health endpoint

### DIFF
--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -1,0 +1,14 @@
+//! Health check handler.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde_json::json;
+
+/// `GET /health` — liveness probe.
+///
+/// Returns `200 OK` with `{ "status": "ok" }` when the server is running.
+/// No database connectivity is verified here; this is a pure liveness check.
+pub async fn health_check() -> impl IntoResponse {
+    (StatusCode::OK, Json(json!({ "status": "ok" })))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,7 @@
+//! HTTP request handlers.
+//!
+//! Each submodule handles one domain area. Handlers orchestrate
+//! request extraction, delegation to repositories, and response
+//! serialization — they contain no business logic or SQL.
+
+pub mod health;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,6 @@
 //! entrypoint (`main.rs`) and by integration tests.
 
 pub mod error;
+pub mod handlers;
 pub mod models;
+pub mod router;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,61 @@
-fn main() {
-    println!("CardPulse API");
+use cardpulse_api::router::build_router;
+use dotenvy::dotenv;
+use std::env;
+use tokio::net::TcpListener;
+use tokio::signal;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+#[tokio::main]
+async fn main() {
+    // Load .env before reading any env vars
+    dotenv().ok();
+
+    // Initialise tracing with RUST_LOG filter
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("{host}:{port}");
+
+    let app = build_router();
+
+    let listener = TcpListener::bind(&addr)
+        .await
+        .expect("failed to bind address");
+    tracing::info!("listening on {addr}");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .expect("server error");
+}
+
+/// Waits for SIGTERM or Ctrl-C and resolves, triggering graceful shutdown.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    tracing::info!("shutdown signal received");
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,14 @@
+//! Application router assembly.
+//!
+//! Builds the axum [`Router`] with all routes mounted.
+//! Keeping routing separate from `main.rs` allows integration tests
+//! to instantiate the full router without binding a real port.
+
+use axum::Router;
+
+use crate::handlers::health::health_check;
+
+/// Builds and returns the complete application router.
+pub fn build_router() -> Router {
+    Router::new().route("/health", axum::routing::get(health_check))
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,13 @@
+//! Shared test helpers for integration tests.
+
+use axum::Router;
+use axum_test::TestServer;
+use cardpulse_api::router::build_router;
+
+/// Spawns an in-process test server with the full application router.
+///
+/// Uses `axum-test` so no real port binding is required.
+pub fn spawn_test_app() -> TestServer {
+    let app: Router = build_router();
+    TestServer::new(app).expect("failed to create test server")
+}

--- a/tests/health_test.rs
+++ b/tests/health_test.rs
@@ -1,0 +1,18 @@
+mod common;
+
+use axum::http::StatusCode;
+
+/// GET /health should return 200 with `{ "status": "ok" }`.
+#[tokio::test]
+async fn test_health_returns_200_with_status_ok() {
+    // Arrange
+    let server = common::spawn_test_app();
+
+    // Act
+    let response = server.get("/health").await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["status"], "ok", "Expected {{ \"status\": \"ok\" }}");
+}


### PR DESCRIPTION
## Summary
- Add `GET /health` returning `200 { "status": "ok" }`
- `main.rs` with `#[tokio::main]`, `HOST:PORT` from env via `dotenvy`, tracing via `RUST_LOG`
- Graceful shutdown on SIGTERM / Ctrl-C
- Extract `build_router()` into `src/router.rs` so integration tests can reuse it without binding a real port
- Add `tests/common/mod.rs` with `spawn_test_app()` helper (axum-test, no port binding)
- Integration test covering the happy path

## Acceptance Criteria
- [x] `main.rs` with `#[tokio::main]` async main
- [x] `GET /health` returns `200 { "status": "ok" }`
- [x] Server binds to `HOST:PORT` from env (via dotenvy)
- [x] Tracing subscriber initialized with `RUST_LOG` filter
- [x] Graceful shutdown on SIGTERM
- [x] Integration test: hit `/health` and assert 200

## Test plan
- [x] `cargo test` — 24 tests passing (1 new integration + 23 existing)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied

Resolves #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)