### PR TITLE
fix(docker): bump Rust to 1.88 and fix cargo install args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # ============================================================
 # Stage 1: Development (with hot reload via cargo-watch)
 # ============================================================
-FROM rust:1.82-slim AS development
+FROM rust:1.88-slim AS development
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     pkg-config \
     libssl-dev \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install cargo-watch sqlx-cli --no-default-features --features postgres
+RUN cargo install cargo-watch \
+    && cargo install sqlx-cli --no-default-features --features postgres
 
 WORKDIR /app
 COPY . .
@@ -20,9 +21,9 @@ CMD ["cargo", "watch", "-x", "run"]
 # ============================================================
 # Stage 2: Builder (optimized release build)
 # ============================================================
-FROM rust:1.82-slim AS builder
+FROM rust:1.88-slim AS builder
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Bump `rust:1.82` → `rust:1.88` — Cargo 1.82 rejects `edition2024` (required by `base64ct` and transitive deps); `cargo-watch` also requires rustc ≥ 1.87
- Split `cargo install cargo-watch sqlx-cli --features postgres` into two separate commands — `--features` applies to all packages in a single call, but `cargo-watch` has no `postgres` feature
- Add `apt-get upgrade -y` to patch vulnerable base image packages

## Root causes
| Error | Cause | Fix |
|---|---|---|
| `edition2024` not supported | Rust 1.82 too old | Bump to `rust:1.88-slim` |
| `cargo-watch` has no feature `postgres` | Single install applies flags to all pkgs | Separate `cargo install` calls |
| CVE warnings | Outdated base packages | `apt-get upgrade -y` |

## Test plan
- [x] `make up` completes successfully — all 3 containers healthy (db, db-test, api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)