### PR TITLE
feat(api): POST /v1/test scaffolding endpoint with AppState

### DIFF
--- a/migrations/002_test_blobs.sql
+++ b/migrations/002_test_blobs.sql
@@ -1,0 +1,7 @@
+-- Temporary scaffolding table for the POST /v1/test endpoint.
+-- MUST be removed before Phase 1 along with the endpoint itself.
+CREATE TABLE IF NOT EXISTS test_blobs (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    data       TEXT        NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,3 +5,4 @@
 //! serialization — they contain no business logic or SQL.
 
 pub mod health;
+pub mod test_blob;

--- a/src/handlers/test_blob.rs
+++ b/src/handlers/test_blob.rs
@@ -1,0 +1,78 @@
+//! Temporary scaffolding handler for `POST /v1/test` and `GET /v1/test/:id`.
+//!
+//! Validates the full request → handler → sqlx → response pipeline.
+//! **Remove this module before Phase 1.**
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{error::AppError, state::AppState};
+
+/// Request body for `POST /v1/test`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateBlobRequest {
+    pub data: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct BlobRow {
+    id: Uuid,
+    data: String,
+}
+
+/// `POST /v1/test` — persist a base64 blob and return its generated UUID.
+///
+/// # Responses
+/// - `201 Created` — `{ "data": { "id": "<uuid>" } }`
+/// - `422 Unprocessable Entity` — missing or invalid `data` field
+/// - `500 Internal Server Error` — database failure
+pub async fn create_blob(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateBlobRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let row = sqlx::query_as::<_, BlobRow>(
+        "INSERT INTO test_blobs (data) VALUES ($1) RETURNING id, data",
+    )
+    .bind(&payload.data)
+    .fetch_one(&state.pool)
+    .await
+    .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({ "data": { "id": row.id } })),
+    ))
+}
+
+/// `GET /v1/test/:id` — retrieve a previously stored blob by UUID.
+///
+/// # Responses
+/// - `200 OK` — `{ "data": { "id": "<uuid>", "data": "<base64>" } }`
+/// - `404 Not Found` — no blob with the given id
+/// - `500 Internal Server Error` — database failure
+pub async fn get_blob(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let row = sqlx::query_as::<_, BlobRow>("SELECT id, data FROM test_blobs WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.pool)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("blob {id} not found")))?;
+
+    Ok(Json(json!({
+        "data": {
+            "id": row.id,
+            "data": row.data
+        }
+    })))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod error;
 pub mod handlers;
 pub mod models;
 pub mod router;
+pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
-use cardpulse_api::router::build_router;
+use cardpulse_api::{config::AppConfig, db::init_pool, router::build_router, state::AppState};
 use dotenvy::dotenv;
-use std::env;
 use tokio::net::TcpListener;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -16,11 +15,15 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let addr = format!("{host}:{port}");
+    let config = AppConfig::from_env();
+    let addr = format!("{}:{}", config.host, config.port);
 
-    let app = build_router();
+    let pool = init_pool(&config.database_url)
+        .await
+        .expect("failed to connect to database");
+
+    let state = AppState::new(pool);
+    let app = build_router(state);
 
     let listener = TcpListener::bind(&addr)
         .await

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,8 +7,14 @@
 use axum::Router;
 
 use crate::handlers::health::health_check;
+use crate::handlers::test_blob::{create_blob, get_blob};
+use crate::state::AppState;
 
-/// Builds and returns the complete application router.
-pub fn build_router() -> Router {
-    Router::new().route("/health", axum::routing::get(health_check))
+/// Builds and returns the complete application router with shared state.
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/health", axum::routing::get(health_check))
+        .route("/v1/test", axum::routing::post(create_blob))
+        .route("/v1/test/:id", axum::routing::get(get_blob))
+        .with_state(state)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,19 @@
+//! Shared application state injected into every handler via axum [`State`].
+
+use sqlx::PgPool;
+
+/// Holds resources shared across all request handlers.
+///
+/// Cloned cheaply for each handler call — all fields use `Arc` internally.
+#[derive(Debug, Clone)]
+pub struct AppState {
+    /// Database connection pool.
+    pub pool: PgPool,
+}
+
+impl AppState {
+    /// Creates a new [`AppState`] wrapping the given pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,17 +1,8 @@
 //! Shared test helpers for integration tests.
 
-use axum::Router;
 use axum_test::TestServer;
-use cardpulse_api::router::build_router;
+use cardpulse_api::{router::build_router, state::AppState};
 use sqlx::PgPool;
-
-/// Spawns an in-process test server with the full application router.
-///
-/// Uses `axum-test` so no real port binding is required.
-pub fn spawn_test_app() -> TestServer {
-    let app: Router = build_router();
-    TestServer::new(app).expect("failed to create test server")
-}
 
 /// Returns a [`PgPool`] connected to the test database with all migrations run.
 ///
@@ -23,4 +14,17 @@ pub async fn test_pool() -> PgPool {
     cardpulse_api::db::init_pool(&url)
         .await
         .expect("failed to connect to test database")
+}
+
+/// Spawns an in-process test server backed by the given pool.
+pub async fn spawn_test_app_with_state(pool: PgPool) -> TestServer {
+    let state = AppState::new(pool);
+    let app = build_router(state);
+    TestServer::new(app).expect("failed to create test server")
+}
+
+/// Spawns an in-process test server connected to the test database.
+pub async fn spawn_test_app() -> TestServer {
+    let pool = test_pool().await;
+    spawn_test_app_with_state(pool).await
 }

--- a/tests/health_test.rs
+++ b/tests/health_test.rs
@@ -6,7 +6,7 @@ use axum::http::StatusCode;
 #[tokio::test]
 async fn test_health_returns_200_with_status_ok() {
     // Arrange
-    let server = common::spawn_test_app();
+    let server = common::spawn_test_app().await;
 
     // Act
     let response = server.get("/health").await;

--- a/tests/test_blob_test.rs
+++ b/tests/test_blob_test.rs
@@ -1,0 +1,84 @@
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+
+#[tokio::test]
+async fn test_post_blob_with_valid_payload_returns_201_with_id() {
+    // Arrange
+    let pool = common::test_pool().await;
+    let server = common::spawn_test_app_with_state(pool).await;
+
+    // Act
+    let response = server
+        .post("/v1/test")
+        .json(&json!({ "data": "aGVsbG8gd29ybGQ=" }))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::CREATED,
+        "Expected 201 Created"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(
+        body["data"]["id"].is_string(),
+        "Expected a UUID id in response"
+    );
+}
+
+#[tokio::test]
+async fn test_get_blob_returns_data_matching_what_was_posted() {
+    // Arrange
+    let pool = common::test_pool().await;
+    let server = common::spawn_test_app_with_state(pool).await;
+    let payload = json!({ "data": "aGVsbG8gd29ybGQ=" });
+
+    // Act — POST
+    let post_response = server.post("/v1/test").json(&payload).await;
+    assert_eq!(post_response.status_code(), StatusCode::CREATED);
+    let post_body: serde_json::Value = post_response.json();
+    let id = post_body["data"]["id"].as_str().unwrap();
+
+    // Act — GET
+    let get_response = server.get(&format!("/v1/test/{id}")).await;
+
+    // Assert
+    assert_eq!(get_response.status_code(), StatusCode::OK);
+    let get_body: serde_json::Value = get_response.json();
+    assert_eq!(
+        get_body["data"]["data"], "aGVsbG8gd29ybGQ=",
+        "Retrieved data must match what was posted"
+    );
+}
+
+#[tokio::test]
+async fn test_post_blob_without_data_field_returns_422() {
+    // Arrange
+    let pool = common::test_pool().await;
+    let server = common::spawn_test_app_with_state(pool).await;
+
+    // Act
+    let response = server.post("/v1/test").json(&json!({})).await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_get_blob_with_unknown_id_returns_404() {
+    // Arrange
+    let pool = common::test_pool().await;
+    let server = common::spawn_test_app_with_state(pool).await;
+
+    // Act
+    let response = server
+        .get("/v1/test/00000000-0000-0000-0000-000000000000")
+        .await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "NOT_FOUND");
+}


### PR DESCRIPTION
## Summary
- `src/state.rs` — `AppState` wrapping `PgPool`, shared via axum `State`
- `src/handlers/test_blob.rs` — `POST /v1/test` (201 + id) and `GET /v1/test/:id` (200 + data | 404) using runtime `sqlx::query_as`
- `migrations/002_test_blobs.sql` — temporary `test_blobs` table (**to be removed before Phase 1**)
- `src/router.rs` — `build_router(state: AppState)` now takes shared state
- `src/main.rs` — wires `AppConfig` + `init_pool` + `AppState` at startup
- `tests/common/mod.rs` — `spawn_test_app_with_state()` helper; `spawn_test_app()` made async
- `tests/test_blob_test.rs` — 4 integration tests

## Acceptance Criteria
- [x] `POST /v1/test` accepts `{ "data": "base64string" }` and inserts into test table
- [x] Returns `201 { "data": { "id": "uuid" } }`
- [x] Uses `AppState` with `PgPool` injected via axum `State`
- [x] Error handling through `AppError` (404 on unknown id, 422 on missing field)
- [x] Integration test: POST → verify 201 → GET → verify data matches

## Test plan
- [x] `cargo test` — 31 tests passing
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied

> **Note:** `test_blobs` table and this endpoint must be removed before Phase 1.

Resolves #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)