### PR TITLE
feat(auth): implement JWT auth middleware (AuthUser extractor)

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -1,0 +1,58 @@
+//! JWT authentication extractor.
+//!
+//! Provides [`AuthUser`], an axum extractor that validates the Bearer token
+//! from the `Authorization` header and extracts the authenticated user's ID.
+
+use async_trait::async_trait;
+use axum::{
+    extract::FromRequestParts,
+    http::{header::AUTHORIZATION, request::Parts},
+};
+
+use crate::auth::jwt::validate_token;
+use crate::error::AppError;
+use crate::models::user::UserId;
+use crate::state::AppState;
+
+/// Extractor that validates the JWT Bearer token and yields the caller's [`UserId`].
+///
+/// Use this in any handler that requires authentication:
+///
+/// ```ignore
+/// async fn protected(AuthUser(user_id): AuthUser) -> impl IntoResponse { ... }
+/// ```
+///
+/// # Errors
+/// Returns [`AppError::Unauthorized`] when:
+/// - The `Authorization` header is missing
+/// - The header value is not a valid `Bearer <token>` format
+/// - The JWT signature is invalid or the token has expired
+#[derive(Debug, Clone)]
+pub struct AuthUser(pub UserId);
+
+#[async_trait]
+impl FromRequestParts<AppState> for AuthUser {
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let header_value = parts
+            .headers
+            .get(AUTHORIZATION)
+            .ok_or_else(|| AppError::Unauthorized("missing Authorization header".into()))?;
+
+        let header_str = header_value
+            .to_str()
+            .map_err(|_| AppError::Unauthorized("invalid Authorization header".into()))?;
+
+        let token = header_str
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| AppError::Unauthorized("invalid Authorization header format".into()))?;
+
+        let claims = validate_token(token, &state.jwt_secret)?;
+
+        Ok(AuthUser(UserId(claims.user_id)))
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod handler;
 pub mod jwt;
+pub mod middleware;
 pub mod password;

--- a/src/handlers/me.rs
+++ b/src/handlers/me.rs
@@ -1,0 +1,20 @@
+//! Handler for the authenticated user identity endpoint.
+
+use axum::{response::IntoResponse, Json};
+use serde_json::json;
+
+use crate::auth::middleware::AuthUser;
+use crate::error::AppError;
+
+/// Returns the authenticated user's ID.
+///
+/// **GET /v1/me**
+///
+/// Requires a valid Bearer token in the `Authorization` header.
+///
+/// ## Responses
+/// - `200 OK` — `{ "data": { "user_id": "<uuid>" } }`
+/// - `401 Unauthorized` — missing or invalid token
+pub async fn me(AuthUser(user_id): AuthUser) -> Result<impl IntoResponse, AppError> {
+    Ok(Json(json!({ "data": { "user_id": user_id } })))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,4 +5,5 @@
 //! serialization — they contain no business logic or SQL.
 
 pub mod health;
+pub mod me;
 pub mod test_blob;

--- a/src/router.rs
+++ b/src/router.rs
@@ -8,6 +8,7 @@ use axum::Router;
 
 use crate::auth::handler::{login, register};
 use crate::handlers::health::health_check;
+use crate::handlers::me::me;
 use crate::handlers::test_blob::{create_blob, get_blob};
 use crate::state::AppState;
 
@@ -17,6 +18,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/health", axum::routing::get(health_check))
         .route("/auth/register", axum::routing::post(register))
         .route("/auth/login", axum::routing::post(login))
+        .route("/v1/me", axum::routing::get(me))
         .route("/v1/test", axum::routing::post(create_blob))
         .route("/v1/test/:id", axum::routing::get(get_blob))
         .with_state(state)

--- a/tests/auth_middleware_test.rs
+++ b/tests/auth_middleware_test.rs
@@ -1,0 +1,178 @@
+mod common;
+
+use axum::http::{header::HeaderValue, StatusCode};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Generates a unique email for each test run.
+fn unique_email(prefix: &str) -> String {
+    format!("{prefix}+{}@example.com", Uuid::new_v4())
+}
+
+/// Registers a user and logs in, returning the JWT token.
+async fn register_and_login(server: &axum_test::TestServer) -> String {
+    let email = unique_email("middleware");
+    server
+        .post("/auth/register")
+        .json(&json!({
+            "email": email,
+            "password": "testpassword123",
+            "wrapped_dek": "aGVsbG8gd29ybGQ=",
+            "dek_salt": "c2FsdHNhbHQ=",
+            "dek_params": "{\"m\":65536}"
+        }))
+        .await;
+
+    let response = server
+        .post("/auth/login")
+        .json(&json!({ "email": email, "password": "testpassword123" }))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    body["data"]["token"]
+        .as_str()
+        .expect("login must return a token")
+        .to_string()
+}
+
+// ── Happy path ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_protected_endpoint_with_valid_token_returns_200() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server).await;
+
+    // Act
+    let response = server
+        .get("/v1/me")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse::<HeaderValue>().unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Expected 200 OK for valid Bearer token"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(
+        body["data"]["user_id"].is_string(),
+        "Response must include user_id"
+    );
+}
+
+// ── Missing Authorization header ──────────────────────────────────────────
+
+#[tokio::test]
+async fn test_protected_endpoint_without_auth_header_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — no Authorization header
+    let response = server.get("/v1/me").await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing Authorization header"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+// ── Malformed Authorization header ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_protected_endpoint_with_malformed_header_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — header without "Bearer " prefix
+    let response = server
+        .get("/v1/me")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            "NotBearer sometoken".parse::<HeaderValue>().unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for malformed Authorization header"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+// ── Invalid JWT signature ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_protected_endpoint_with_invalid_token_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — completely bogus token
+    let response = server
+        .get("/v1/me")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            "Bearer this.is.not.a.valid.jwt"
+                .parse::<HeaderValue>()
+                .unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for invalid JWT"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+// ── Expired token ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_protected_endpoint_with_expired_token_returns_401() {
+    // Arrange — create a token that already expired (0 hours = already past)
+    let user_id = Uuid::new_v4();
+    let secret = "ci-secret-minimum-64-chars-long-for-hs256-validation-in-tests-ok";
+
+    // Manually build an expired token using jsonwebtoken
+    let claims = serde_json::json!({ "user_id": user_id.to_string(), "exp": 0 });
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap();
+
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .get("/v1/me")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse::<HeaderValue>().unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for expired JWT"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}


### PR DESCRIPTION
## Summary
- Add `AuthUser(UserId)` extractor implementing `FromRequestParts` that validates Bearer tokens from the Authorization header
- Verify JWT signature and expiration via `validate_token`, returning `AppError::Unauthorized` for all failure cases
- Add `GET /v1/me` endpoint as the first protected route using the new extractor
- Integration tests covering: valid token (200), missing header (401), malformed header (401), invalid JWT (401), expired token (401)

Closes #10

## Test plan
- [x] `test_protected_endpoint_with_valid_token_returns_200` — happy path
- [x] `test_protected_endpoint_without_auth_header_returns_401` — missing header
- [x] `test_protected_endpoint_with_malformed_header_returns_401` — no Bearer prefix
- [x] `test_protected_endpoint_with_invalid_token_returns_401` — bogus JWT
- [x] `test_protected_endpoint_with_expired_token_returns_401` — expired JWT
- [x] All existing tests remain green (38 total)
- [x] `make fmt` and `make lint` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)