### PR TITLE
feat(auth): implement POST /auth/refresh for JWT token renewal

### DIFF
--- a/src/auth/handler.rs
+++ b/src/auth/handler.rs
@@ -3,6 +3,7 @@
 //! # Endpoints
 //! - `POST /auth/register` — create a new user account
 //! - `POST /auth/login`    — verify credentials, return JWT + wrapped DEK
+//! - `POST /auth/refresh`  — renew a valid JWT before expiration
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -12,6 +13,7 @@ use serde_json::json;
 use crate::{
     auth::{
         jwt::create_token,
+        middleware::AuthUser,
         password::{hash_password, verify_password},
     },
     error::AppError,
@@ -107,4 +109,20 @@ pub async fn login(
             "dek_params":  user.dek_params,
         }
     })))
+}
+
+/// `POST /auth/refresh` — renew a valid JWT before expiration.
+///
+/// Takes the current Bearer token (validated by [`AuthUser`] extractor),
+/// and issues a new token with the same `user_id` and a fresh expiration.
+///
+/// # Responses
+/// - `200 OK` — `{ "data": { "token": "<new-jwt>" } }`
+/// - `401 Unauthorized` — missing, invalid, or expired token
+pub async fn refresh(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> Result<impl IntoResponse, AppError> {
+    let token = create_token(user_id.0, &state.jwt_secret, state.jwt_expiration_hours)?;
+    Ok(Json(json!({ "data": { "token": token } })))
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,7 +6,7 @@
 
 use axum::Router;
 
-use crate::auth::handler::{login, register};
+use crate::auth::handler::{login, refresh, register};
 use crate::handlers::health::health_check;
 use crate::handlers::me::me;
 use crate::handlers::test_blob::{create_blob, get_blob};
@@ -18,6 +18,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/health", axum::routing::get(health_check))
         .route("/auth/register", axum::routing::post(register))
         .route("/auth/login", axum::routing::post(login))
+        .route("/auth/refresh", axum::routing::post(refresh))
         .route("/v1/me", axum::routing::get(me))
         .route("/v1/test", axum::routing::post(create_blob))
         .route("/v1/test/:id", axum::routing::get(get_blob))

--- a/tests/auth_refresh_test.rs
+++ b/tests/auth_refresh_test.rs
@@ -1,0 +1,150 @@
+mod common;
+
+use axum::http::{header::HeaderValue, StatusCode};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Generates a unique email for each test run.
+fn unique_email(prefix: &str) -> String {
+    format!("{prefix}+{}@example.com", Uuid::new_v4())
+}
+
+/// Registers a user and logs in, returning the JWT token.
+async fn register_and_login(server: &axum_test::TestServer) -> String {
+    let email = unique_email("refresh");
+    server
+        .post("/auth/register")
+        .json(&json!({
+            "email": email,
+            "password": "testpassword123",
+            "wrapped_dek": "aGVsbG8gd29ybGQ=",
+            "dek_salt": "c2FsdHNhbHQ=",
+            "dek_params": "{\"m\":65536}"
+        }))
+        .await;
+
+    let response = server
+        .post("/auth/login")
+        .json(&json!({ "email": email, "password": "testpassword123" }))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    body["data"]["token"]
+        .as_str()
+        .expect("login must return a token")
+        .to_string()
+}
+
+// ── Happy path ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_refresh_with_valid_token_returns_200_with_new_token() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server).await;
+
+    // Act
+    let response = server
+        .post("/auth/refresh")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse::<HeaderValue>().unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Expected 200 OK for valid refresh"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(
+        body["data"]["token"].is_string(),
+        "Response must include a new token"
+    );
+}
+
+// ── Missing Authorization header ──────────────────────────────────────────
+
+#[tokio::test]
+async fn test_refresh_without_auth_header_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server.post("/auth/refresh").await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing Authorization header"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+// ── Expired token ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_refresh_with_expired_token_returns_401() {
+    // Arrange — manually build an already-expired token
+    let user_id = Uuid::new_v4();
+    let secret = "ci-secret-minimum-64-chars-long-for-hs256-validation-in-tests-ok";
+    let claims = serde_json::json!({ "user_id": user_id.to_string(), "exp": 0 });
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap();
+
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .post("/auth/refresh")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse::<HeaderValue>().unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for expired token"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+// ── Invalid token ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_refresh_with_invalid_token_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .post("/auth/refresh")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            "Bearer totally.invalid.token"
+                .parse::<HeaderValue>()
+                .unwrap(),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for invalid token"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}


### PR DESCRIPTION
## Summary
- Add `POST /auth/refresh` endpoint that validates the current Bearer token and issues a new JWT with a fresh expiration
- Reuses the `AuthUser` extractor from #10 for token validation — expired/invalid/missing tokens are rejected with 401
- Handler delegates to `create_token` with the same `user_id` from the validated claims

Closes #11

## Test plan
- [x] `test_refresh_with_valid_token_returns_200_with_new_token` — happy path
- [x] `test_refresh_without_auth_header_returns_401` — missing header
- [x] `test_refresh_with_expired_token_returns_401` — expired JWT
- [x] `test_refresh_with_invalid_token_returns_401` — invalid JWT
- [x] All existing tests remain green (46 total)
- [x] `make fmt` and `make lint` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)