### PR TITLE
feat(cards): implement CRUD for /v1/cards with ownership checks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,10 @@ pub enum AppError {
     #[error("{0}")]
     Unauthorized(String),
 
+    /// The authenticated user does not have permission to access this resource.
+    #[error("{0}")]
+    Forbidden(String),
+
     /// The resource already exists (e.g. duplicate email).
     #[error("{0}")]
     Conflict(String),
@@ -43,6 +47,7 @@ impl AppError {
         match self {
             AppError::NotFound(_) => StatusCode::NOT_FOUND,
             AppError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            AppError::Forbidden(_) => StatusCode::FORBIDDEN,
             AppError::Conflict(_) => StatusCode::CONFLICT,
             AppError::ValidationError(_) => StatusCode::UNPROCESSABLE_ENTITY,
             AppError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -54,6 +59,7 @@ impl AppError {
         match self {
             AppError::NotFound(_) => "NOT_FOUND",
             AppError::Unauthorized(_) => "UNAUTHORIZED",
+            AppError::Forbidden(_) => "FORBIDDEN",
             AppError::Conflict(_) => "CONFLICT",
             AppError::ValidationError(_) => "VALIDATION_ERROR",
             AppError::InternalError(_) => "INTERNAL_ERROR",
@@ -130,6 +136,15 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(body["error"]["code"], "VALIDATION_ERROR");
         assert_eq!(body["error"]["message"], "invalid payload");
+    }
+
+    #[tokio::test]
+    async fn test_forbidden_returns_403_with_correct_body() {
+        let (status, body) = parse_response(AppError::Forbidden("not your resource".into())).await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["error"]["code"], "FORBIDDEN");
+        assert_eq!(body["error"]["message"], "not your resource");
     }
 
     #[tokio::test]

--- a/src/handlers/cards.rs
+++ b/src/handlers/cards.rs
@@ -1,0 +1,177 @@
+//! Card CRUD handlers.
+//!
+//! # Endpoints
+//! - `POST /v1/cards`     — create a new card
+//! - `GET /v1/cards`      — list the authenticated user's cards
+//! - `PUT /v1/cards/:id`  — update a card
+//! - `DELETE /v1/cards/:id` — delete a card
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{
+    auth::middleware::AuthUser,
+    error::AppError,
+    models::card::{CardResponse, CreateCard},
+    repositories::{
+        card_repo::PgCardRepository,
+        traits::{CardRepository, NewCard, UpdateCard},
+    },
+    state::AppState,
+};
+
+/// Builds a [`CardResponse`] from a domain [`Card`], encoding binary fields as base64.
+fn card_to_response(card: crate::models::card::Card) -> CardResponse {
+    CardResponse {
+        id: card.id,
+        user_id: card.user_id,
+        encrypted_data: STANDARD.encode(&card.encrypted_data),
+        iv: STANDARD.encode(&card.iv),
+        auth_tag: STANDARD.encode(&card.auth_tag),
+        created_at: card.created_at,
+    }
+}
+
+/// Decoded binary card fields from a base64-encoded request.
+struct DecodedCardFields {
+    encrypted_data: Vec<u8>,
+    iv: Vec<u8>,
+    auth_tag: Vec<u8>,
+}
+
+/// Decodes base64-encoded card fields, returning a validation error on failure.
+fn decode_card_fields(payload: &CreateCard) -> Result<DecodedCardFields, AppError> {
+    let encrypted_data = STANDARD
+        .decode(&payload.encrypted_data)
+        .map_err(|_| AppError::ValidationError("encrypted_data is not valid base64".into()))?;
+    let iv = STANDARD
+        .decode(&payload.iv)
+        .map_err(|_| AppError::ValidationError("iv is not valid base64".into()))?;
+    let auth_tag = STANDARD
+        .decode(&payload.auth_tag)
+        .map_err(|_| AppError::ValidationError("auth_tag is not valid base64".into()))?;
+    Ok(DecodedCardFields {
+        encrypted_data,
+        iv,
+        auth_tag,
+    })
+}
+
+/// `POST /v1/cards` — create a new encrypted card.
+///
+/// # Responses
+/// - `201 Created` — `{ "data": { ... } }`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `422 Unprocessable Entity` — invalid payload
+pub async fn create_card(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(payload): Json<CreateCard>,
+) -> Result<impl IntoResponse, AppError> {
+    let decoded = decode_card_fields(&payload)?;
+
+    let repo = PgCardRepository::new(state.pool);
+    let card = repo
+        .create(NewCard {
+            user_id: user_id.0,
+            encrypted_data: decoded.encrypted_data,
+            iv: decoded.iv,
+            auth_tag: decoded.auth_tag,
+        })
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({ "data": card_to_response(card) })),
+    ))
+}
+
+/// `GET /v1/cards` — list all cards for the authenticated user.
+///
+/// # Responses
+/// - `200 OK` — `{ "data": [ ... ] }`
+/// - `401 Unauthorized` — missing or invalid token
+pub async fn list_cards(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> Result<impl IntoResponse, AppError> {
+    let repo = PgCardRepository::new(state.pool);
+    let cards = repo.find_all_by_user_id(user_id.0).await?;
+
+    let data: Vec<CardResponse> = cards.into_iter().map(card_to_response).collect();
+
+    Ok(Json(json!({ "data": data })))
+}
+
+/// `PUT /v1/cards/:id` — update an existing card.
+///
+/// # Responses
+/// - `200 OK` — `{ "data": { ... } }`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `403 Forbidden` — card belongs to another user
+/// - `404 Not Found` — card does not exist
+/// - `422 Unprocessable Entity` — invalid payload
+pub async fn update_card(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<CreateCard>,
+) -> Result<impl IntoResponse, AppError> {
+    let repo = PgCardRepository::new(state.pool);
+
+    // Ownership check
+    let existing = repo.find_by_id(id).await?;
+    if existing.user_id != user_id.0 {
+        return Err(AppError::Forbidden(
+            "you do not have access to this card".into(),
+        ));
+    }
+
+    let decoded = decode_card_fields(&payload)?;
+    let card = repo
+        .update(
+            id,
+            UpdateCard {
+                encrypted_data: decoded.encrypted_data,
+                iv: decoded.iv,
+                auth_tag: decoded.auth_tag,
+            },
+        )
+        .await?;
+
+    Ok(Json(json!({ "data": card_to_response(card) })))
+}
+
+/// `DELETE /v1/cards/:id` — delete a card.
+///
+/// # Responses
+/// - `204 No Content`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `403 Forbidden` — card belongs to another user
+/// - `404 Not Found` — card does not exist
+pub async fn delete_card(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let repo = PgCardRepository::new(state.pool);
+
+    // Ownership check
+    let existing = repo.find_by_id(id).await?;
+    if existing.user_id != user_id.0 {
+        return Err(AppError::Forbidden(
+            "you do not have access to this card".into(),
+        ));
+    }
+
+    repo.delete(id).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,6 +4,7 @@
 //! request extraction, delegation to repositories, and response
 //! serialization — they contain no business logic or SQL.
 
+pub mod cards;
 pub mod health;
 pub mod me;
 pub mod test_blob;

--- a/src/models/card.rs
+++ b/src/models/card.rs
@@ -18,7 +18,7 @@ impl std::fmt::Display for CardId {
 ///
 /// All card data is encrypted client-side; the server stores only
 /// opaque blobs and never inspects the plaintext content.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Card {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/src/repositories/card_repo.rs
+++ b/src/repositories/card_repo.rs
@@ -1,0 +1,96 @@
+//! PostgreSQL implementation of [`CardRepository`].
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    models::card::Card,
+    repositories::traits::{CardRepository, NewCard, UpdateCard},
+};
+
+/// Postgres-backed card repository.
+pub struct PgCardRepository {
+    pool: PgPool,
+}
+
+impl PgCardRepository {
+    /// Creates a new repository using the given connection pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CardRepository for PgCardRepository {
+    async fn create(&self, new_card: NewCard) -> Result<Card, AppError> {
+        sqlx::query_as::<_, Card>(
+            "INSERT INTO cards (user_id, encrypted_data, iv, auth_tag)
+             VALUES ($1, $2, $3, $4)
+             RETURNING id, user_id, encrypted_data, iv, auth_tag, created_at",
+        )
+        .bind(new_card.user_id)
+        .bind(&new_card.encrypted_data)
+        .bind(&new_card.iv)
+        .bind(&new_card.auth_tag)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))
+    }
+
+    async fn find_by_id(&self, id: Uuid) -> Result<Card, AppError> {
+        sqlx::query_as::<_, Card>(
+            "SELECT id, user_id, encrypted_data, iv, auth_tag, created_at
+             FROM cards WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("card '{id}' not found")))
+    }
+
+    async fn find_all_by_user_id(&self, user_id: Uuid) -> Result<Vec<Card>, AppError> {
+        sqlx::query_as::<_, Card>(
+            "SELECT id, user_id, encrypted_data, iv, auth_tag, created_at
+             FROM cards WHERE user_id = $1
+             ORDER BY created_at DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))
+    }
+
+    async fn update(&self, id: Uuid, data: UpdateCard) -> Result<Card, AppError> {
+        sqlx::query_as::<_, Card>(
+            "UPDATE cards
+             SET encrypted_data = $1, iv = $2, auth_tag = $3
+             WHERE id = $4
+             RETURNING id, user_id, encrypted_data, iv, auth_tag, created_at",
+        )
+        .bind(&data.encrypted_data)
+        .bind(&data.iv)
+        .bind(&data.auth_tag)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("card '{id}' not found")))
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<(), AppError> {
+        let result = sqlx::query("DELETE FROM cards WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound(format!("card '{id}' not found")));
+        }
+
+        Ok(())
+    }
+}

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -3,5 +3,6 @@
 //! Handlers depend on the traits in [`traits`], not on the concrete
 //! implementations, keeping business logic decoupled from SQL.
 
+pub mod card_repo;
 pub mod traits;
 pub mod user_repo;

--- a/src/repositories/traits.rs
+++ b/src/repositories/traits.rs
@@ -6,7 +6,10 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::{error::AppError, models::user::User};
+use crate::{
+    error::AppError,
+    models::{card::Card, user::User},
+};
 
 /// Data needed to create a new user row.
 pub struct NewUser {
@@ -33,4 +36,56 @@ pub trait UserRepository: Send + Sync {
     /// - [`AppError::NotFound`] if no user with that email exists.
     /// - [`AppError::InternalError`] on database error.
     async fn find_by_email(&self, email: &str) -> Result<User, AppError>;
+}
+
+/// Data needed to create a new card row.
+pub struct NewCard {
+    pub user_id: Uuid,
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+}
+
+/// Data needed to update an existing card row.
+pub struct UpdateCard {
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+}
+
+/// Persistence operations for the `cards` table.
+#[async_trait]
+pub trait CardRepository: Send + Sync {
+    /// Inserts a new card and returns the full [`Card`].
+    ///
+    /// # Errors
+    /// - [`AppError::InternalError`] on database error.
+    async fn create(&self, new_card: NewCard) -> Result<Card, AppError>;
+
+    /// Fetches a single card by its ID.
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no card with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn find_by_id(&self, id: Uuid) -> Result<Card, AppError>;
+
+    /// Lists all cards belonging to a user.
+    ///
+    /// # Errors
+    /// - [`AppError::InternalError`] on database error.
+    async fn find_all_by_user_id(&self, user_id: Uuid) -> Result<Vec<Card>, AppError>;
+
+    /// Updates a card's encrypted data and returns the updated [`Card`].
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no card with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn update(&self, id: Uuid, data: UpdateCard) -> Result<Card, AppError>;
+
+    /// Deletes a card by its ID.
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no card with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn delete(&self, id: Uuid) -> Result<(), AppError>;
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,6 +7,7 @@
 use axum::Router;
 
 use crate::auth::handler::{login, refresh, register};
+use crate::handlers::cards::{create_card, delete_card, list_cards, update_card};
 use crate::handlers::health::health_check;
 use crate::handlers::me::me;
 use crate::handlers::test_blob::{create_blob, get_blob};
@@ -20,6 +21,14 @@ pub fn build_router(state: AppState) -> Router {
         .route("/auth/login", axum::routing::post(login))
         .route("/auth/refresh", axum::routing::post(refresh))
         .route("/v1/me", axum::routing::get(me))
+        .route(
+            "/v1/cards",
+            axum::routing::post(create_card).get(list_cards),
+        )
+        .route(
+            "/v1/cards/:id",
+            axum::routing::put(update_card).delete(delete_card),
+        )
         .route("/v1/test", axum::routing::post(create_blob))
         .route("/v1/test/:id", axum::routing::get(get_blob))
         .with_state(state)

--- a/tests/cards_test.rs
+++ b/tests/cards_test.rs
@@ -1,0 +1,398 @@
+mod common;
+
+use axum::http::{header::HeaderValue, StatusCode};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Generates a unique email for each test run.
+fn unique_email(prefix: &str) -> String {
+    format!("{prefix}+{}@example.com", Uuid::new_v4())
+}
+
+/// Registers a user and logs in, returning the JWT token.
+async fn register_and_login(server: &axum_test::TestServer, prefix: &str) -> String {
+    let email = unique_email(prefix);
+    server
+        .post("/auth/register")
+        .json(&json!({
+            "email": email,
+            "password": "testpassword123",
+            "wrapped_dek": "aGVsbG8gd29ybGQ=",
+            "dek_salt": "c2FsdHNhbHQ=",
+            "dek_params": "{\"m\":65536}"
+        }))
+        .await;
+
+    let response = server
+        .post("/auth/login")
+        .json(&json!({ "email": email, "password": "testpassword123" }))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    body["data"]["token"]
+        .as_str()
+        .expect("login must return a token")
+        .to_string()
+}
+
+fn card_payload() -> serde_json::Value {
+    json!({
+        "encrypted_data": "aGVsbG8gd29ybGQ=",
+        "iv": "c29tZWl2MTIzNA==",
+        "auth_tag": "dGFnMTIzNDU2Nzg="
+    })
+}
+
+fn bearer(token: &str) -> HeaderValue {
+    format!("Bearer {token}").parse().unwrap()
+}
+
+/// Creates a card and returns its ID.
+async fn create_test_card(server: &axum_test::TestServer, token: &str) -> Uuid {
+    let response = server
+        .post("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(token))
+        .json(&card_payload())
+        .await;
+
+    let body: serde_json::Value = response.json();
+    Uuid::parse_str(body["data"]["id"].as_str().unwrap()).unwrap()
+}
+
+// ── POST /v1/cards ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_card_with_valid_payload_returns_201() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "create").await;
+
+    // Act
+    let response = server
+        .post("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&card_payload())
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::CREATED,
+        "Expected 201 Created for valid card"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(body["data"]["id"].is_string(), "Response must include id");
+    assert!(
+        body["data"]["encrypted_data"].is_string(),
+        "Response must include encrypted_data"
+    );
+}
+
+#[tokio::test]
+async fn test_create_card_without_auth_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server.post("/v1/cards").json(&card_payload()).await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing auth"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+}
+
+#[tokio::test]
+async fn test_create_card_with_missing_fields_returns_422() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "create-invalid").await;
+
+    // Act — payload missing required fields
+    let response = server
+        .post("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&json!({ "encrypted_data": "aGVsbG8=" }))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "Expected 422 for missing fields"
+    );
+}
+
+// ── GET /v1/cards ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_cards_returns_200_with_array() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "list").await;
+
+    // Create two cards
+    create_test_card(&server, &token).await;
+    create_test_card(&server, &token).await;
+
+    // Act
+    let response = server
+        .get("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Expected 200 OK for card listing"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(body["data"].is_array(), "Response must be an array");
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        2,
+        "Expected 2 cards"
+    );
+}
+
+#[tokio::test]
+async fn test_list_cards_without_auth_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server.get("/v1/cards").await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing auth"
+    );
+}
+
+#[tokio::test]
+async fn test_list_cards_returns_only_own_cards() {
+    // Arrange — two different users
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "list-a").await;
+    let token_b = register_and_login(&server, "list-b").await;
+
+    // User A creates 2 cards, User B creates 1
+    create_test_card(&server, &token_a).await;
+    create_test_card(&server, &token_a).await;
+    create_test_card(&server, &token_b).await;
+
+    // Act — User A lists cards
+    let response = server
+        .get("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_a))
+        .await;
+
+    // Assert
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        2,
+        "User A should only see their own 2 cards"
+    );
+}
+
+// ── PUT /v1/cards/:id ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_update_card_with_valid_payload_returns_200() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "update").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    let updated_payload = json!({
+        "encrypted_data": "dXBkYXRlZA==",
+        "iv": "bmV3aXYxMjM0NTY=",
+        "auth_tag": "bmV3dGFnMTIzNDU2"
+    });
+
+    // Act
+    let response = server
+        .put(&format!("/v1/cards/{card_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&updated_payload)
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Expected 200 OK for valid update"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["data"]["encrypted_data"], "dXBkYXRlZA==");
+}
+
+#[tokio::test]
+async fn test_update_card_without_auth_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "update-noauth").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    // Act
+    let response = server
+        .put(&format!("/v1/cards/{card_id}"))
+        .json(&card_payload())
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing auth"
+    );
+}
+
+#[tokio::test]
+async fn test_update_card_not_found_returns_404() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "update-404").await;
+    let fake_id = Uuid::new_v4();
+
+    // Act
+    let response = server
+        .put(&format!("/v1/cards/{fake_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&card_payload())
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::NOT_FOUND,
+        "Expected 404 for nonexistent card"
+    );
+}
+
+#[tokio::test]
+async fn test_update_card_owned_by_another_user_returns_403() {
+    // Arrange — User A creates a card, User B tries to update it
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "update-a").await;
+    let token_b = register_and_login(&server, "update-b").await;
+    let card_id = create_test_card(&server, &token_a).await;
+
+    // Act
+    let response = server
+        .put(&format!("/v1/cards/{card_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_b))
+        .json(&card_payload())
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::FORBIDDEN,
+        "Expected 403 for ownership violation"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "FORBIDDEN");
+}
+
+// ── DELETE /v1/cards/:id ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_delete_card_returns_204() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "delete").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    // Act
+    let response = server
+        .delete(&format!("/v1/cards/{card_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::NO_CONTENT,
+        "Expected 204 No Content for successful delete"
+    );
+
+    // Verify card is gone
+    let list_response = server
+        .get("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+    let body: serde_json::Value = list_response.json();
+    assert_eq!(body["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_delete_card_without_auth_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "delete-noauth").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    // Act
+    let response = server.delete(&format!("/v1/cards/{card_id}")).await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing auth"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_card_not_found_returns_404() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "delete-404").await;
+    let fake_id = Uuid::new_v4();
+
+    // Act
+    let response = server
+        .delete(&format!("/v1/cards/{fake_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::NOT_FOUND,
+        "Expected 404 for nonexistent card"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_card_owned_by_another_user_returns_403() {
+    // Arrange — User A creates a card, User B tries to delete it
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "delete-a").await;
+    let token_b = register_and_login(&server, "delete-b").await;
+    let card_id = create_test_card(&server, &token_a).await;
+
+    // Act
+    let response = server
+        .delete(&format!("/v1/cards/{card_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_b))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::FORBIDDEN,
+        "Expected 403 for ownership violation"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "FORBIDDEN");
+}


### PR DESCRIPTION
## Summary
- Add full CRUD endpoints for encrypted card data: `POST`, `GET`, `PUT`, `DELETE` on `/v1/cards`
- Add `CardRepository` trait and `PgCardRepository` implementation following the repository pattern
- Add `AppError::Forbidden` variant (403) for ownership violations
- All endpoints require authentication; users can only access their own cards
- Base64 decoding/encoding for encrypted fields at the handler boundary

Closes #12

## New files
- `src/handlers/cards.rs` — CRUD handlers with ownership checks
- `src/repositories/card_repo.rs` — `PgCardRepository` implementation
- `tests/cards_test.rs` — 14 integration tests

## Modified files
- `src/error.rs` — added `Forbidden` variant (403)
- `src/repositories/traits.rs` — added `CardRepository` trait, `NewCard`, `UpdateCard` DTOs
- `src/models/card.rs` — added `sqlx::FromRow` derive to `Card`
- `src/router.rs` — mounted `/v1/cards` and `/v1/cards/:id` routes
- `src/handlers/mod.rs`, `src/repositories/mod.rs` — module registrations

## Test plan
- [x] `test_create_card_with_valid_payload_returns_201`
- [x] `test_create_card_without_auth_returns_401`
- [x] `test_create_card_with_missing_fields_returns_422`
- [x] `test_list_cards_returns_200_with_array`
- [x] `test_list_cards_without_auth_returns_401`
- [x] `test_list_cards_returns_only_own_cards`
- [x] `test_update_card_with_valid_payload_returns_200`
- [x] `test_update_card_without_auth_returns_401`
- [x] `test_update_card_not_found_returns_404`
- [x] `test_update_card_owned_by_another_user_returns_403`
- [x] `test_delete_card_returns_204`
- [x] `test_delete_card_without_auth_returns_401`
- [x] `test_delete_card_not_found_returns_404`
- [x] `test_delete_card_owned_by_another_user_returns_403`
- [x] All 61 tests pass, `make fmt` and `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)