### PR TITLE
feat(transactions): implement CRUD for /v1/transactions with filtering

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -8,3 +8,4 @@ pub mod cards;
 pub mod health;
 pub mod me;
 pub mod test_blob;
+pub mod transactions;

--- a/src/handlers/transactions.rs
+++ b/src/handlers/transactions.rs
@@ -1,0 +1,333 @@
+//! Transaction CRUD handlers.
+//!
+//! # Endpoints
+//! - `POST /v1/transactions`      — create one or many transactions
+//! - `GET /v1/transactions`       — list with optional `card_id` and `timestamp_bucket` filters
+//! - `PUT /v1/transactions/:id`   — update a transaction
+//! - `DELETE /v1/transactions/:id` — delete a transaction
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{
+    auth::middleware::AuthUser,
+    error::AppError,
+    models::transaction::{CreateTransaction, TransactionResponse},
+    repositories::{
+        card_repo::PgCardRepository,
+        traits::{
+            CardRepository, NewTransaction, TransactionFilters, TransactionRepository,
+            UpdateTransaction,
+        },
+        transaction_repo::PgTransactionRepository,
+    },
+    state::AppState,
+};
+
+/// Validates that `timestamp_bucket` matches the `YYYY-MM` format.
+fn validate_timestamp_bucket(bucket: &str) -> Result<(), AppError> {
+    if bucket.len() != 7 {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be in YYYY-MM format".into(),
+        ));
+    }
+
+    let parts: Vec<&str> = bucket.split('-').collect();
+    if parts.len() != 2 {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be in YYYY-MM format".into(),
+        ));
+    }
+
+    let year: u16 = parts[0].parse().map_err(|_| {
+        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
+    })?;
+    let month: u8 = parts[1].parse().map_err(|_| {
+        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
+    })?;
+
+    if year < 2000 || !(1..=12).contains(&month) {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be a valid YYYY-MM date".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Decoded binary transaction fields from a base64-encoded request.
+struct DecodedTxFields {
+    encrypted_data: Vec<u8>,
+    iv: Vec<u8>,
+    auth_tag: Vec<u8>,
+}
+
+/// Decodes base64-encoded transaction fields.
+fn decode_tx_fields(
+    encrypted_data: &str,
+    iv: &str,
+    auth_tag: &str,
+) -> Result<DecodedTxFields, AppError> {
+    let encrypted_data = STANDARD
+        .decode(encrypted_data)
+        .map_err(|_| AppError::ValidationError("encrypted_data is not valid base64".into()))?;
+    let iv = STANDARD
+        .decode(iv)
+        .map_err(|_| AppError::ValidationError("iv is not valid base64".into()))?;
+    let auth_tag = STANDARD
+        .decode(auth_tag)
+        .map_err(|_| AppError::ValidationError("auth_tag is not valid base64".into()))?;
+    Ok(DecodedTxFields {
+        encrypted_data,
+        iv,
+        auth_tag,
+    })
+}
+
+/// Builds a [`TransactionResponse`] from a domain [`Transaction`].
+fn tx_to_response(tx: crate::models::transaction::Transaction) -> TransactionResponse {
+    TransactionResponse {
+        id: tx.id,
+        user_id: tx.user_id,
+        card_id: tx.card_id,
+        encrypted_data: STANDARD.encode(&tx.encrypted_data),
+        iv: STANDARD.encode(&tx.iv),
+        auth_tag: STANDARD.encode(&tx.auth_tag),
+        timestamp_bucket: tx.timestamp_bucket,
+        created_at: tx.created_at,
+    }
+}
+
+/// Verifies that `card_id` exists and belongs to `user_id`.
+async fn verify_card_ownership(
+    pool: &sqlx::PgPool,
+    card_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    let card_repo = PgCardRepository::new(pool.clone());
+    let card = card_repo.find_by_id(card_id).await?;
+    if card.user_id != user_id {
+        return Err(AppError::Forbidden(
+            "card does not belong to the authenticated user".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Request body for bulk or single transaction creation.
+///
+/// Accepts either a single `CreateTransaction` or an array of them.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum CreateTransactionPayload {
+    /// A list of transactions to create.
+    Bulk(Vec<CreateTransaction>),
+    /// A single transaction to create.
+    Single(CreateTransaction),
+}
+
+/// `POST /v1/transactions` — create one or many encrypted transactions.
+///
+/// Accepts either a single transaction object or an array for bulk creation.
+///
+/// # Responses
+/// - `201 Created` — `{ "data": { ... } }` or `{ "data": [ ... ] }`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `403 Forbidden` — card does not belong to the user
+/// - `404 Not Found` — card does not exist
+/// - `422 Unprocessable Entity` — invalid payload or timestamp_bucket
+pub async fn create_transaction(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(payload): Json<CreateTransactionPayload>,
+) -> Result<impl IntoResponse, AppError> {
+    let items = match payload {
+        CreateTransactionPayload::Single(item) => vec![item],
+        CreateTransactionPayload::Bulk(items) => items,
+    };
+
+    if items.is_empty() {
+        return Err(AppError::ValidationError(
+            "at least one transaction is required".into(),
+        ));
+    }
+
+    let repo = PgTransactionRepository::new(state.pool.clone());
+    let mut responses = Vec::with_capacity(items.len());
+
+    for item in &items {
+        validate_timestamp_bucket(&item.timestamp_bucket)?;
+        verify_card_ownership(&state.pool, item.card_id, user_id.0).await?;
+    }
+
+    for item in items {
+        let decoded = decode_tx_fields(&item.encrypted_data, &item.iv, &item.auth_tag)?;
+        let tx = repo
+            .create(NewTransaction {
+                user_id: user_id.0,
+                card_id: item.card_id,
+                encrypted_data: decoded.encrypted_data,
+                iv: decoded.iv,
+                auth_tag: decoded.auth_tag,
+                timestamp_bucket: item.timestamp_bucket,
+            })
+            .await?;
+        responses.push(tx_to_response(tx));
+    }
+
+    if responses.len() == 1 {
+        Ok((
+            StatusCode::CREATED,
+            Json(json!({ "data": responses.into_iter().next().unwrap() })),
+        ))
+    } else {
+        Ok((StatusCode::CREATED, Json(json!({ "data": responses }))))
+    }
+}
+
+/// Query parameters for listing transactions.
+#[derive(Debug, Deserialize)]
+pub struct ListTransactionsQuery {
+    pub card_id: Option<Uuid>,
+    pub timestamp_bucket: Option<String>,
+}
+
+/// `GET /v1/transactions` — list transactions with optional filters.
+///
+/// # Query parameters
+/// - `card_id` — filter by card UUID
+/// - `timestamp_bucket` — filter by "YYYY-MM" bucket
+///
+/// # Responses
+/// - `200 OK` — `{ "data": [ ... ] }`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `422 Unprocessable Entity` — invalid timestamp_bucket format
+pub async fn list_transactions(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Query(query): Query<ListTransactionsQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    if let Some(ref bucket) = query.timestamp_bucket {
+        validate_timestamp_bucket(bucket)?;
+    }
+
+    let repo = PgTransactionRepository::new(state.pool);
+    let txs = repo
+        .find_all_by_user_id(
+            user_id.0,
+            TransactionFilters {
+                card_id: query.card_id,
+                timestamp_bucket: query.timestamp_bucket,
+            },
+        )
+        .await?;
+
+    let data: Vec<TransactionResponse> = txs.into_iter().map(tx_to_response).collect();
+
+    Ok(Json(json!({ "data": data })))
+}
+
+/// `PUT /v1/transactions/:id` — update an existing transaction.
+///
+/// # Responses
+/// - `200 OK` — `{ "data": { ... } }`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `403 Forbidden` — transaction belongs to another user
+/// - `404 Not Found` — transaction does not exist
+/// - `422 Unprocessable Entity` — invalid payload or timestamp_bucket
+pub async fn update_transaction(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<CreateTransaction>,
+) -> Result<impl IntoResponse, AppError> {
+    validate_timestamp_bucket(&payload.timestamp_bucket)?;
+
+    let repo = PgTransactionRepository::new(state.pool.clone());
+
+    // Ownership check
+    let existing = repo.find_by_id(id).await?;
+    if existing.user_id != user_id.0 {
+        return Err(AppError::Forbidden(
+            "you do not have access to this transaction".into(),
+        ));
+    }
+
+    // Verify new card_id ownership if changed
+    if payload.card_id != existing.card_id {
+        verify_card_ownership(&state.pool, payload.card_id, user_id.0).await?;
+    }
+
+    let decoded = decode_tx_fields(&payload.encrypted_data, &payload.iv, &payload.auth_tag)?;
+    let tx = repo
+        .update(
+            id,
+            UpdateTransaction {
+                encrypted_data: decoded.encrypted_data,
+                iv: decoded.iv,
+                auth_tag: decoded.auth_tag,
+                timestamp_bucket: payload.timestamp_bucket,
+            },
+        )
+        .await?;
+
+    Ok(Json(json!({ "data": tx_to_response(tx) })))
+}
+
+/// `DELETE /v1/transactions/:id` — delete a transaction.
+///
+/// # Responses
+/// - `204 No Content`
+/// - `401 Unauthorized` — missing or invalid token
+/// - `403 Forbidden` — transaction belongs to another user
+/// - `404 Not Found` — transaction does not exist
+pub async fn delete_transaction(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let repo = PgTransactionRepository::new(state.pool);
+
+    // Ownership check
+    let existing = repo.find_by_id(id).await?;
+    if existing.user_id != user_id.0 {
+        return Err(AppError::Forbidden(
+            "you do not have access to this transaction".into(),
+        ));
+    }
+
+    repo.delete(id).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_timestamp_bucket_accepts_valid_format() {
+        assert!(validate_timestamp_bucket("2025-01").is_ok());
+        assert!(validate_timestamp_bucket("2025-12").is_ok());
+        assert!(validate_timestamp_bucket("2000-06").is_ok());
+    }
+
+    #[test]
+    fn test_validate_timestamp_bucket_rejects_invalid_format() {
+        assert!(validate_timestamp_bucket("2025").is_err());
+        assert!(validate_timestamp_bucket("2025-1").is_err());
+        assert!(validate_timestamp_bucket("2025-13").is_err());
+        assert!(validate_timestamp_bucket("2025-00").is_err());
+        assert!(validate_timestamp_bucket("abcd-01").is_err());
+        assert!(validate_timestamp_bucket("25-01").is_err());
+        assert!(validate_timestamp_bucket("").is_err());
+    }
+}

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -19,7 +19,7 @@ impl std::fmt::Display for TransactionId {
 /// All financial data is encrypted client-side. The only temporal
 /// metadata stored in plaintext is `timestamp_bucket` ("YYYY-MM"),
 /// which allows filtering without exposing exact timestamps.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Transaction {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod card_repo;
 pub mod traits;
+pub mod transaction_repo;
 pub mod user_repo;

--- a/src/repositories/traits.rs
+++ b/src/repositories/traits.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     error::AppError,
-    models::{card::Card, user::User},
+    models::{card::Card, transaction::Transaction, user::User},
 };
 
 /// Data needed to create a new user row.
@@ -86,6 +86,71 @@ pub trait CardRepository: Send + Sync {
     ///
     /// # Errors
     /// - [`AppError::NotFound`] if no card with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn delete(&self, id: Uuid) -> Result<(), AppError>;
+}
+
+/// Data needed to create a new transaction row.
+pub struct NewTransaction {
+    pub user_id: Uuid,
+    pub card_id: Uuid,
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+    pub timestamp_bucket: String,
+}
+
+/// Data needed to update an existing transaction row.
+pub struct UpdateTransaction {
+    pub encrypted_data: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub auth_tag: Vec<u8>,
+    pub timestamp_bucket: String,
+}
+
+/// Optional filters for listing transactions.
+pub struct TransactionFilters {
+    pub card_id: Option<Uuid>,
+    pub timestamp_bucket: Option<String>,
+}
+
+/// Persistence operations for the `transactions` table.
+#[async_trait]
+pub trait TransactionRepository: Send + Sync {
+    /// Inserts a new transaction and returns the full [`Transaction`].
+    ///
+    /// # Errors
+    /// - [`AppError::InternalError`] on database error.
+    async fn create(&self, new_tx: NewTransaction) -> Result<Transaction, AppError>;
+
+    /// Fetches a single transaction by its ID.
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no transaction with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn find_by_id(&self, id: Uuid) -> Result<Transaction, AppError>;
+
+    /// Lists transactions belonging to a user with optional filters.
+    ///
+    /// # Errors
+    /// - [`AppError::InternalError`] on database error.
+    async fn find_all_by_user_id(
+        &self,
+        user_id: Uuid,
+        filters: TransactionFilters,
+    ) -> Result<Vec<Transaction>, AppError>;
+
+    /// Updates a transaction and returns the updated [`Transaction`].
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no transaction with that ID exists.
+    /// - [`AppError::InternalError`] on database error.
+    async fn update(&self, id: Uuid, data: UpdateTransaction) -> Result<Transaction, AppError>;
+
+    /// Deletes a transaction by its ID.
+    ///
+    /// # Errors
+    /// - [`AppError::NotFound`] if no transaction with that ID exists.
     /// - [`AppError::InternalError`] on database error.
     async fn delete(&self, id: Uuid) -> Result<(), AppError>;
 }

--- a/src/repositories/transaction_repo.rs
+++ b/src/repositories/transaction_repo.rs
@@ -1,0 +1,124 @@
+//! PostgreSQL implementation of [`TransactionRepository`].
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    models::transaction::Transaction,
+    repositories::traits::{
+        NewTransaction, TransactionFilters, TransactionRepository, UpdateTransaction,
+    },
+};
+
+/// Postgres-backed transaction repository.
+pub struct PgTransactionRepository {
+    pool: PgPool,
+}
+
+impl PgTransactionRepository {
+    /// Creates a new repository using the given connection pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+const SELECT_COLS: &str =
+    "id, user_id, card_id, encrypted_data, iv, auth_tag, timestamp_bucket, created_at";
+
+#[async_trait]
+impl TransactionRepository for PgTransactionRepository {
+    async fn create(&self, new_tx: NewTransaction) -> Result<Transaction, AppError> {
+        let query = format!(
+            "INSERT INTO transactions (user_id, card_id, encrypted_data, iv, auth_tag, timestamp_bucket)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING {SELECT_COLS}"
+        );
+        sqlx::query_as::<_, Transaction>(&query)
+            .bind(new_tx.user_id)
+            .bind(new_tx.card_id)
+            .bind(&new_tx.encrypted_data)
+            .bind(&new_tx.iv)
+            .bind(&new_tx.auth_tag)
+            .bind(&new_tx.timestamp_bucket)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))
+    }
+
+    async fn find_by_id(&self, id: Uuid) -> Result<Transaction, AppError> {
+        let query = format!("SELECT {SELECT_COLS} FROM transactions WHERE id = $1");
+        sqlx::query_as::<_, Transaction>(&query)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound(format!("transaction '{id}' not found")))
+    }
+
+    async fn find_all_by_user_id(
+        &self,
+        user_id: Uuid,
+        filters: TransactionFilters,
+    ) -> Result<Vec<Transaction>, AppError> {
+        let mut sql = format!("SELECT {SELECT_COLS} FROM transactions WHERE user_id = $1");
+        let mut param_index = 2u32;
+
+        if filters.card_id.is_some() {
+            sql.push_str(&format!(" AND card_id = ${param_index}"));
+            param_index += 1;
+        }
+        if filters.timestamp_bucket.is_some() {
+            sql.push_str(&format!(" AND timestamp_bucket = ${param_index}"));
+        }
+        sql.push_str(" ORDER BY created_at DESC");
+
+        let mut query = sqlx::query_as::<_, Transaction>(&sql).bind(user_id);
+
+        if let Some(card_id) = filters.card_id {
+            query = query.bind(card_id);
+        }
+        if let Some(bucket) = filters.timestamp_bucket {
+            query = query.bind(bucket);
+        }
+
+        query
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))
+    }
+
+    async fn update(&self, id: Uuid, data: UpdateTransaction) -> Result<Transaction, AppError> {
+        let query = format!(
+            "UPDATE transactions
+             SET encrypted_data = $1, iv = $2, auth_tag = $3, timestamp_bucket = $4
+             WHERE id = $5
+             RETURNING {SELECT_COLS}"
+        );
+        sqlx::query_as::<_, Transaction>(&query)
+            .bind(&data.encrypted_data)
+            .bind(&data.iv)
+            .bind(&data.auth_tag)
+            .bind(&data.timestamp_bucket)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound(format!("transaction '{id}' not found")))
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<(), AppError> {
+        let result = sqlx::query("DELETE FROM transactions WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(AppError::NotFound(format!("transaction '{id}' not found")));
+        }
+
+        Ok(())
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,6 +11,9 @@ use crate::handlers::cards::{create_card, delete_card, list_cards, update_card};
 use crate::handlers::health::health_check;
 use crate::handlers::me::me;
 use crate::handlers::test_blob::{create_blob, get_blob};
+use crate::handlers::transactions::{
+    create_transaction, delete_transaction, list_transactions, update_transaction,
+};
 use crate::state::AppState;
 
 /// Builds and returns the complete application router with shared state.
@@ -28,6 +31,14 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/v1/cards/:id",
             axum::routing::put(update_card).delete(delete_card),
+        )
+        .route(
+            "/v1/transactions",
+            axum::routing::post(create_transaction).get(list_transactions),
+        )
+        .route(
+            "/v1/transactions/:id",
+            axum::routing::put(update_transaction).delete(delete_transaction),
         )
         .route("/v1/test", axum::routing::post(create_blob))
         .route("/v1/test/:id", axum::routing::get(get_blob))

--- a/tests/transactions_test.rs
+++ b/tests/transactions_test.rs
@@ -1,0 +1,523 @@
+mod common;
+
+use axum::http::{header::HeaderValue, StatusCode};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Generates a unique email for each test run.
+fn unique_email(prefix: &str) -> String {
+    format!("{prefix}+{}@example.com", Uuid::new_v4())
+}
+
+/// Registers a user and logs in, returning the JWT token.
+async fn register_and_login(server: &axum_test::TestServer, prefix: &str) -> String {
+    let email = unique_email(prefix);
+    server
+        .post("/auth/register")
+        .json(&json!({
+            "email": email,
+            "password": "testpassword123",
+            "wrapped_dek": "aGVsbG8gd29ybGQ=",
+            "dek_salt": "c2FsdHNhbHQ=",
+            "dek_params": "{\"m\":65536}"
+        }))
+        .await;
+
+    let response = server
+        .post("/auth/login")
+        .json(&json!({ "email": email, "password": "testpassword123" }))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    body["data"]["token"]
+        .as_str()
+        .expect("login must return a token")
+        .to_string()
+}
+
+fn bearer(token: &str) -> HeaderValue {
+    format!("Bearer {token}").parse().unwrap()
+}
+
+/// Creates a card and returns its ID.
+async fn create_test_card(server: &axum_test::TestServer, token: &str) -> Uuid {
+    let response = server
+        .post("/v1/cards")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(token))
+        .json(&json!({
+            "encrypted_data": "aGVsbG8gd29ybGQ=",
+            "iv": "c29tZWl2MTIzNA==",
+            "auth_tag": "dGFnMTIzNDU2Nzg="
+        }))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    Uuid::parse_str(body["data"]["id"].as_str().unwrap()).unwrap()
+}
+
+fn tx_payload(card_id: Uuid, bucket: &str) -> serde_json::Value {
+    json!({
+        "card_id": card_id,
+        "encrypted_data": "dHhkYXRh",
+        "iv": "dHhpdjEyMzQ=",
+        "auth_tag": "dHh0YWcxMjM0",
+        "timestamp_bucket": bucket
+    })
+}
+
+/// Creates a transaction and returns its ID.
+async fn create_test_tx(
+    server: &axum_test::TestServer,
+    token: &str,
+    card_id: Uuid,
+    bucket: &str,
+) -> Uuid {
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(token))
+        .json(&tx_payload(card_id, bucket))
+        .await;
+
+    let body: serde_json::Value = response.json();
+    Uuid::parse_str(body["data"]["id"].as_str().unwrap()).unwrap()
+}
+
+// ── POST /v1/transactions ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_transaction_with_valid_payload_returns_201() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-create").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&tx_payload(card_id, "2025-03"))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::CREATED,
+        "Expected 201 Created for valid transaction"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(body["data"]["id"].is_string(), "Response must include id");
+    assert_eq!(body["data"]["card_id"], card_id.to_string());
+    assert_eq!(body["data"]["timestamp_bucket"], "2025-03");
+}
+
+#[tokio::test]
+async fn test_create_transaction_bulk_returns_201_with_array() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-bulk").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    let bulk = json!([
+        tx_payload(card_id, "2025-01"),
+        tx_payload(card_id, "2025-02"),
+    ]);
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&bulk)
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::CREATED,
+        "Expected 201 for bulk create"
+    );
+    let body: serde_json::Value = response.json();
+    assert!(body["data"].is_array(), "Bulk response must be an array");
+    assert_eq!(body["data"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_create_transaction_without_auth_returns_401() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .json(&json!({
+            "card_id": Uuid::new_v4(),
+            "encrypted_data": "dHhkYXRh",
+            "iv": "dHhpdjEyMzQ=",
+            "auth_tag": "dHh0YWcxMjM0",
+            "timestamp_bucket": "2025-03"
+        }))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 for missing auth"
+    );
+}
+
+#[tokio::test]
+async fn test_create_transaction_with_invalid_bucket_returns_422() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-bad-bucket").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&tx_payload(card_id, "not-valid"))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "Expected 422 for invalid timestamp_bucket"
+    );
+}
+
+#[tokio::test]
+async fn test_create_transaction_with_nonexistent_card_returns_404() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-no-card").await;
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&tx_payload(Uuid::new_v4(), "2025-03"))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::NOT_FOUND,
+        "Expected 404 for nonexistent card"
+    );
+}
+
+#[tokio::test]
+async fn test_create_transaction_with_other_users_card_returns_403() {
+    // Arrange — User A's card, User B tries to create tx
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "tx-card-a").await;
+    let token_b = register_and_login(&server, "tx-card-b").await;
+    let card_id = create_test_card(&server, &token_a).await;
+
+    // Act
+    let response = server
+        .post("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_b))
+        .json(&tx_payload(card_id, "2025-03"))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::FORBIDDEN,
+        "Expected 403 for using another user's card"
+    );
+}
+
+// ── GET /v1/transactions ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_transactions_returns_200_with_array() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-list").await;
+    let card_id = create_test_card(&server, &token).await;
+    create_test_tx(&server, &token, card_id, "2025-01").await;
+    create_test_tx(&server, &token, card_id, "2025-02").await;
+
+    // Act
+    let response = server
+        .get("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["data"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_list_transactions_without_auth_returns_401() {
+    let server = common::spawn_test_app().await;
+    let response = server.get("/v1/transactions").await;
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_list_transactions_filters_by_card_id() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-filter-card").await;
+    let card_a = create_test_card(&server, &token).await;
+    let card_b = create_test_card(&server, &token).await;
+    create_test_tx(&server, &token, card_a, "2025-03").await;
+    create_test_tx(&server, &token, card_a, "2025-03").await;
+    create_test_tx(&server, &token, card_b, "2025-03").await;
+
+    // Act
+    let response = server
+        .get(&format!("/v1/transactions?card_id={card_a}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        2,
+        "Should only return transactions for card_a"
+    );
+}
+
+#[tokio::test]
+async fn test_list_transactions_filters_by_timestamp_bucket() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-filter-bucket").await;
+    let card_id = create_test_card(&server, &token).await;
+    create_test_tx(&server, &token, card_id, "2025-01").await;
+    create_test_tx(&server, &token, card_id, "2025-02").await;
+    create_test_tx(&server, &token, card_id, "2025-02").await;
+
+    // Act
+    let response = server
+        .get("/v1/transactions?timestamp_bucket=2025-02")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        2,
+        "Should only return transactions for 2025-02"
+    );
+}
+
+#[tokio::test]
+async fn test_list_transactions_returns_only_own_transactions() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "tx-own-a").await;
+    let token_b = register_and_login(&server, "tx-own-b").await;
+    let card_a = create_test_card(&server, &token_a).await;
+    let card_b = create_test_card(&server, &token_b).await;
+    create_test_tx(&server, &token_a, card_a, "2025-03").await;
+    create_test_tx(&server, &token_b, card_b, "2025-03").await;
+
+    // Act
+    let response = server
+        .get("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_a))
+        .await;
+
+    // Assert
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body["data"].as_array().unwrap().len(),
+        1,
+        "User A should only see their own transaction"
+    );
+}
+
+// ── PUT /v1/transactions/:id ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_update_transaction_with_valid_payload_returns_200() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-update").await;
+    let card_id = create_test_card(&server, &token).await;
+    let tx_id = create_test_tx(&server, &token, card_id, "2025-03").await;
+
+    let updated = json!({
+        "card_id": card_id,
+        "encrypted_data": "dXBkYXRlZA==",
+        "iv": "bmV3aXYxMjM0NTY=",
+        "auth_tag": "bmV3dGFnMTIzNDU2",
+        "timestamp_bucket": "2025-04"
+    });
+
+    // Act
+    let response = server
+        .put(&format!("/v1/transactions/{tx_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&updated)
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Expected 200 for valid update"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["data"]["timestamp_bucket"], "2025-04");
+    assert_eq!(body["data"]["encrypted_data"], "dXBkYXRlZA==");
+}
+
+#[tokio::test]
+async fn test_update_transaction_without_auth_returns_401() {
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-update-noauth").await;
+    let card_id = create_test_card(&server, &token).await;
+    let tx_id = create_test_tx(&server, &token, card_id, "2025-03").await;
+
+    let response = server
+        .put(&format!("/v1/transactions/{tx_id}"))
+        .json(&tx_payload(card_id, "2025-03"))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_update_transaction_not_found_returns_404() {
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-update-404").await;
+    let card_id = create_test_card(&server, &token).await;
+
+    let response = server
+        .put(&format!("/v1/transactions/{}", Uuid::new_v4()))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&tx_payload(card_id, "2025-03"))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_transaction_owned_by_another_user_returns_403() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "tx-upd-a").await;
+    let token_b = register_and_login(&server, "tx-upd-b").await;
+    let card_a = create_test_card(&server, &token_a).await;
+    let card_b = create_test_card(&server, &token_b).await;
+    let tx_id = create_test_tx(&server, &token_a, card_a, "2025-03").await;
+
+    // Act — User B tries to update User A's transaction
+    let response = server
+        .put(&format!("/v1/transactions/{tx_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_b))
+        .json(&tx_payload(card_b, "2025-03"))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::FORBIDDEN,
+        "Expected 403 for ownership violation"
+    );
+}
+
+#[tokio::test]
+async fn test_update_transaction_with_invalid_bucket_returns_422() {
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-upd-bucket").await;
+    let card_id = create_test_card(&server, &token).await;
+    let tx_id = create_test_tx(&server, &token, card_id, "2025-03").await;
+
+    let response = server
+        .put(&format!("/v1/transactions/{tx_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .json(&tx_payload(card_id, "bad"))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// ── DELETE /v1/transactions/:id ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_delete_transaction_returns_204() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-delete").await;
+    let card_id = create_test_card(&server, &token).await;
+    let tx_id = create_test_tx(&server, &token, card_id, "2025-03").await;
+
+    // Act
+    let response = server
+        .delete(&format!("/v1/transactions/{tx_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::NO_CONTENT,
+        "Expected 204 for successful delete"
+    );
+
+    // Verify transaction is gone
+    let list = server
+        .get("/v1/transactions")
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+    let body: serde_json::Value = list.json();
+    assert_eq!(body["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_delete_transaction_without_auth_returns_401() {
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-del-noauth").await;
+    let card_id = create_test_card(&server, &token).await;
+    let tx_id = create_test_tx(&server, &token, card_id, "2025-03").await;
+
+    let response = server.delete(&format!("/v1/transactions/{tx_id}")).await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_delete_transaction_not_found_returns_404() {
+    let server = common::spawn_test_app().await;
+    let token = register_and_login(&server, "tx-del-404").await;
+
+    let response = server
+        .delete(&format!("/v1/transactions/{}", Uuid::new_v4()))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token))
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_delete_transaction_owned_by_another_user_returns_403() {
+    let server = common::spawn_test_app().await;
+    let token_a = register_and_login(&server, "tx-del-a").await;
+    let token_b = register_and_login(&server, "tx-del-b").await;
+    let card_a = create_test_card(&server, &token_a).await;
+    let tx_id = create_test_tx(&server, &token_a, card_a, "2025-03").await;
+
+    let response = server
+        .delete(&format!("/v1/transactions/{tx_id}"))
+        .add_header(axum::http::header::AUTHORIZATION, bearer(&token_b))
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        StatusCode::FORBIDDEN,
+        "Expected 403 for ownership violation"
+    );
+}


### PR DESCRIPTION
## Summary
- Add full CRUD endpoints for encrypted transactions: `POST`, `GET`, `PUT`, `DELETE` on `/v1/transactions`
- `POST` supports both single and bulk creation (accepts a single object or an array)
- `GET` supports optional `card_id` and `timestamp_bucket` query filters
- `timestamp_bucket` validated as `YYYY-MM` format on create, update, and list
- `card_id` verified to exist and belong to the authenticated user
- `TransactionRepository` trait and `PgTransactionRepository` with dynamic query building for filters
- Ownership enforced on transactions and referenced cards (403 Forbidden)

Closes #13

## New files
- `src/handlers/transactions.rs` — CRUD handlers with validation and ownership checks
- `src/repositories/transaction_repo.rs` — `PgTransactionRepository` implementation
- `tests/transactions_test.rs` — 20 integration tests

## Modified files
- `src/models/transaction.rs` — added `sqlx::FromRow` derive
- `src/repositories/traits.rs` — added `TransactionRepository` trait, `NewTransaction`, `UpdateTransaction`, `TransactionFilters`
- `src/router.rs` — mounted `/v1/transactions` and `/v1/transactions/:id` routes
- `src/handlers/mod.rs`, `src/repositories/mod.rs` — module registrations

## Test plan
**POST /v1/transactions:**
- [x] `test_create_transaction_with_valid_payload_returns_201`
- [x] `test_create_transaction_bulk_returns_201_with_array`
- [x] `test_create_transaction_without_auth_returns_401`
- [x] `test_create_transaction_with_invalid_bucket_returns_422`
- [x] `test_create_transaction_with_nonexistent_card_returns_404`
- [x] `test_create_transaction_with_other_users_card_returns_403`

**GET /v1/transactions:**
- [x] `test_list_transactions_returns_200_with_array`
- [x] `test_list_transactions_without_auth_returns_401`
- [x] `test_list_transactions_filters_by_card_id`
- [x] `test_list_transactions_filters_by_timestamp_bucket`
- [x] `test_list_transactions_returns_only_own_transactions`

**PUT /v1/transactions/:id:**
- [x] `test_update_transaction_with_valid_payload_returns_200`
- [x] `test_update_transaction_without_auth_returns_401`
- [x] `test_update_transaction_not_found_returns_404`
- [x] `test_update_transaction_owned_by_another_user_returns_403`
- [x] `test_update_transaction_with_invalid_bucket_returns_422`

**DELETE /v1/transactions/:id:**
- [x] `test_delete_transaction_returns_204`
- [x] `test_delete_transaction_without_auth_returns_401`
- [x] `test_delete_transaction_not_found_returns_404`
- [x] `test_delete_transaction_owned_by_another_user_returns_403`

**Unit tests:**
- [x] `test_validate_timestamp_bucket_accepts_valid_format`
- [x] `test_validate_timestamp_bucket_rejects_invalid_format`

- [x] All 83 tests pass, `make fmt` and `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)