### PR TITLE
feat(validation): extract reusable request validation helpers

### DIFF
--- a/src/auth/handler.rs
+++ b/src/auth/handler.rs
@@ -23,6 +23,7 @@ use crate::{
         user_repo::PgUserRepository,
     },
     state::AppState,
+    validation::validate_base64,
 };
 
 /// `POST /auth/register` — register a new user.
@@ -41,13 +42,8 @@ pub async fn register(
 ) -> Result<impl IntoResponse, AppError> {
     let password_hash = hash_password(&payload.password)?;
 
-    let wrapped_dek = STANDARD
-        .decode(&payload.wrapped_dek)
-        .map_err(|_| AppError::ValidationError("wrapped_dek is not valid base64".into()))?;
-
-    let dek_salt = STANDARD
-        .decode(&payload.dek_salt)
-        .map_err(|_| AppError::ValidationError("dek_salt is not valid base64".into()))?;
+    let wrapped_dek = validate_base64(&payload.wrapped_dek, "wrapped_dek")?;
+    let dek_salt = validate_base64(&payload.dek_salt, "dek_salt")?;
 
     let repo = PgUserRepository::new(state.pool);
     let id = repo

--- a/src/handlers/cards.rs
+++ b/src/handlers/cards.rs
@@ -25,6 +25,7 @@ use crate::{
         traits::{CardRepository, NewCard, UpdateCard},
     },
     state::AppState,
+    validation::validate_base64,
 };
 
 /// Builds a [`CardResponse`] from a domain [`Card`], encoding binary fields as base64.
@@ -39,31 +40,6 @@ fn card_to_response(card: crate::models::card::Card) -> CardResponse {
     }
 }
 
-/// Decoded binary card fields from a base64-encoded request.
-struct DecodedCardFields {
-    encrypted_data: Vec<u8>,
-    iv: Vec<u8>,
-    auth_tag: Vec<u8>,
-}
-
-/// Decodes base64-encoded card fields, returning a validation error on failure.
-fn decode_card_fields(payload: &CreateCard) -> Result<DecodedCardFields, AppError> {
-    let encrypted_data = STANDARD
-        .decode(&payload.encrypted_data)
-        .map_err(|_| AppError::ValidationError("encrypted_data is not valid base64".into()))?;
-    let iv = STANDARD
-        .decode(&payload.iv)
-        .map_err(|_| AppError::ValidationError("iv is not valid base64".into()))?;
-    let auth_tag = STANDARD
-        .decode(&payload.auth_tag)
-        .map_err(|_| AppError::ValidationError("auth_tag is not valid base64".into()))?;
-    Ok(DecodedCardFields {
-        encrypted_data,
-        iv,
-        auth_tag,
-    })
-}
-
 /// `POST /v1/cards` — create a new encrypted card.
 ///
 /// # Responses
@@ -75,15 +51,17 @@ pub async fn create_card(
     AuthUser(user_id): AuthUser,
     Json(payload): Json<CreateCard>,
 ) -> Result<impl IntoResponse, AppError> {
-    let decoded = decode_card_fields(&payload)?;
+    let encrypted_data = validate_base64(&payload.encrypted_data, "encrypted_data")?;
+    let iv = validate_base64(&payload.iv, "iv")?;
+    let auth_tag = validate_base64(&payload.auth_tag, "auth_tag")?;
 
     let repo = PgCardRepository::new(state.pool);
     let card = repo
         .create(NewCard {
             user_id: user_id.0,
-            encrypted_data: decoded.encrypted_data,
-            iv: decoded.iv,
-            auth_tag: decoded.auth_tag,
+            encrypted_data,
+            iv,
+            auth_tag,
         })
         .await?;
 
@@ -134,14 +112,16 @@ pub async fn update_card(
         ));
     }
 
-    let decoded = decode_card_fields(&payload)?;
+    let encrypted_data = validate_base64(&payload.encrypted_data, "encrypted_data")?;
+    let iv = validate_base64(&payload.iv, "iv")?;
+    let auth_tag = validate_base64(&payload.auth_tag, "auth_tag")?;
     let card = repo
         .update(
             id,
             UpdateCard {
-                encrypted_data: decoded.encrypted_data,
-                iv: decoded.iv,
-                auth_tag: decoded.auth_tag,
+                encrypted_data,
+                iv,
+                auth_tag,
             },
         )
         .await?;

--- a/src/handlers/transactions.rs
+++ b/src/handlers/transactions.rs
@@ -30,67 +30,8 @@ use crate::{
         transaction_repo::PgTransactionRepository,
     },
     state::AppState,
+    validation::{validate_base64, validate_timestamp_bucket},
 };
-
-/// Validates that `timestamp_bucket` matches the `YYYY-MM` format.
-fn validate_timestamp_bucket(bucket: &str) -> Result<(), AppError> {
-    if bucket.len() != 7 {
-        return Err(AppError::ValidationError(
-            "timestamp_bucket must be in YYYY-MM format".into(),
-        ));
-    }
-
-    let parts: Vec<&str> = bucket.split('-').collect();
-    if parts.len() != 2 {
-        return Err(AppError::ValidationError(
-            "timestamp_bucket must be in YYYY-MM format".into(),
-        ));
-    }
-
-    let year: u16 = parts[0].parse().map_err(|_| {
-        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
-    })?;
-    let month: u8 = parts[1].parse().map_err(|_| {
-        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
-    })?;
-
-    if year < 2000 || !(1..=12).contains(&month) {
-        return Err(AppError::ValidationError(
-            "timestamp_bucket must be a valid YYYY-MM date".into(),
-        ));
-    }
-
-    Ok(())
-}
-
-/// Decoded binary transaction fields from a base64-encoded request.
-struct DecodedTxFields {
-    encrypted_data: Vec<u8>,
-    iv: Vec<u8>,
-    auth_tag: Vec<u8>,
-}
-
-/// Decodes base64-encoded transaction fields.
-fn decode_tx_fields(
-    encrypted_data: &str,
-    iv: &str,
-    auth_tag: &str,
-) -> Result<DecodedTxFields, AppError> {
-    let encrypted_data = STANDARD
-        .decode(encrypted_data)
-        .map_err(|_| AppError::ValidationError("encrypted_data is not valid base64".into()))?;
-    let iv = STANDARD
-        .decode(iv)
-        .map_err(|_| AppError::ValidationError("iv is not valid base64".into()))?;
-    let auth_tag = STANDARD
-        .decode(auth_tag)
-        .map_err(|_| AppError::ValidationError("auth_tag is not valid base64".into()))?;
-    Ok(DecodedTxFields {
-        encrypted_data,
-        iv,
-        auth_tag,
-    })
-}
 
 /// Builds a [`TransactionResponse`] from a domain [`Transaction`].
 fn tx_to_response(tx: crate::models::transaction::Transaction) -> TransactionResponse {
@@ -169,14 +110,16 @@ pub async fn create_transaction(
     }
 
     for item in items {
-        let decoded = decode_tx_fields(&item.encrypted_data, &item.iv, &item.auth_tag)?;
+        let encrypted_data = validate_base64(&item.encrypted_data, "encrypted_data")?;
+        let iv = validate_base64(&item.iv, "iv")?;
+        let auth_tag = validate_base64(&item.auth_tag, "auth_tag")?;
         let tx = repo
             .create(NewTransaction {
                 user_id: user_id.0,
                 card_id: item.card_id,
-                encrypted_data: decoded.encrypted_data,
-                iv: decoded.iv,
-                auth_tag: decoded.auth_tag,
+                encrypted_data,
+                iv,
+                auth_tag,
                 timestamp_bucket: item.timestamp_bucket,
             })
             .await?;
@@ -266,14 +209,16 @@ pub async fn update_transaction(
         verify_card_ownership(&state.pool, payload.card_id, user_id.0).await?;
     }
 
-    let decoded = decode_tx_fields(&payload.encrypted_data, &payload.iv, &payload.auth_tag)?;
+    let encrypted_data = validate_base64(&payload.encrypted_data, "encrypted_data")?;
+    let iv = validate_base64(&payload.iv, "iv")?;
+    let auth_tag = validate_base64(&payload.auth_tag, "auth_tag")?;
     let tx = repo
         .update(
             id,
             UpdateTransaction {
-                encrypted_data: decoded.encrypted_data,
-                iv: decoded.iv,
-                auth_tag: decoded.auth_tag,
+                encrypted_data,
+                iv,
+                auth_tag,
                 timestamp_bucket: payload.timestamp_bucket,
             },
         )
@@ -307,27 +252,4 @@ pub async fn delete_transaction(
     repo.delete(id).await?;
 
     Ok(StatusCode::NO_CONTENT)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_validate_timestamp_bucket_accepts_valid_format() {
-        assert!(validate_timestamp_bucket("2025-01").is_ok());
-        assert!(validate_timestamp_bucket("2025-12").is_ok());
-        assert!(validate_timestamp_bucket("2000-06").is_ok());
-    }
-
-    #[test]
-    fn test_validate_timestamp_bucket_rejects_invalid_format() {
-        assert!(validate_timestamp_bucket("2025").is_err());
-        assert!(validate_timestamp_bucket("2025-1").is_err());
-        assert!(validate_timestamp_bucket("2025-13").is_err());
-        assert!(validate_timestamp_bucket("2025-00").is_err());
-        assert!(validate_timestamp_bucket("abcd-01").is_err());
-        assert!(validate_timestamp_bucket("25-01").is_err());
-        assert!(validate_timestamp_bucket("").is_err());
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod models;
 pub mod repositories;
 pub mod router;
 pub mod state;
+pub mod validation;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,217 @@
+//! Reusable request validation helpers.
+//!
+//! Each function returns `Result<(), AppError::ValidationError>` on failure,
+//! making it easy to compose with the `?` operator in handlers.
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+
+use crate::error::AppError;
+
+/// Validates that `bucket` matches the `YYYY-MM` format with a valid date.
+///
+/// Year must be >= 2000, month must be 01–12.
+///
+/// # Errors
+/// Returns [`AppError::ValidationError`] if the format or date is invalid.
+pub fn validate_timestamp_bucket(bucket: &str) -> Result<(), AppError> {
+    if bucket.len() != 7 {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be in YYYY-MM format".into(),
+        ));
+    }
+
+    let parts: Vec<&str> = bucket.split('-').collect();
+    if parts.len() != 2 {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be in YYYY-MM format".into(),
+        ));
+    }
+
+    let year: u16 = parts[0].parse().map_err(|_| {
+        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
+    })?;
+    let month: u8 = parts[1].parse().map_err(|_| {
+        AppError::ValidationError("timestamp_bucket must be in YYYY-MM format".into())
+    })?;
+
+    if year < 2000 || !(1..=12).contains(&month) {
+        return Err(AppError::ValidationError(
+            "timestamp_bucket must be a valid YYYY-MM date".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validates that `value` is a valid standard base64 string.
+///
+/// Uses the standard alphabet with padding. Empty strings are rejected.
+///
+/// # Errors
+/// Returns [`AppError::ValidationError`] with `field_name` in the message
+/// if the value is empty or not valid base64.
+pub fn validate_base64(value: &str, field_name: &str) -> Result<Vec<u8>, AppError> {
+    if value.is_empty() {
+        return Err(AppError::ValidationError(format!(
+            "{field_name} must not be empty"
+        )));
+    }
+
+    STANDARD
+        .decode(value)
+        .map_err(|_| AppError::ValidationError(format!("{field_name} is not valid base64")))
+}
+
+/// Validates that `email` has a basic valid format (contains `@` with parts on both sides).
+///
+/// This is intentionally a lightweight check — full RFC 5322 compliance
+/// is not attempted. The definitive check is the registration flow itself
+/// (e.g. confirmation email).
+///
+/// # Errors
+/// Returns [`AppError::ValidationError`] if the format is clearly invalid.
+pub fn validate_email(email: &str) -> Result<(), AppError> {
+    if email.is_empty() {
+        return Err(AppError::ValidationError("email must not be empty".into()));
+    }
+
+    let parts: Vec<&str> = email.splitn(2, '@').collect();
+    if parts.len() != 2 {
+        return Err(AppError::ValidationError(
+            "email must contain an @ symbol".into(),
+        ));
+    }
+
+    let local = parts[0];
+    let domain = parts[1];
+
+    if local.is_empty() {
+        return Err(AppError::ValidationError(
+            "email must have a local part before @".into(),
+        ));
+    }
+
+    if domain.is_empty() || !domain.contains('.') {
+        return Err(AppError::ValidationError(
+            "email must have a valid domain after @".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── validate_timestamp_bucket ─────────────────────────────────────────
+
+    #[test]
+    fn test_timestamp_bucket_accepts_valid_format() {
+        assert!(validate_timestamp_bucket("2025-01").is_ok());
+        assert!(validate_timestamp_bucket("2025-12").is_ok());
+        assert!(validate_timestamp_bucket("2000-06").is_ok());
+        assert!(validate_timestamp_bucket("2099-11").is_ok());
+    }
+
+    #[test]
+    fn test_timestamp_bucket_rejects_invalid_format() {
+        assert!(validate_timestamp_bucket("2025").is_err());
+        assert!(validate_timestamp_bucket("2025-1").is_err());
+        assert!(validate_timestamp_bucket("25-01").is_err());
+        assert!(validate_timestamp_bucket("").is_err());
+        assert!(validate_timestamp_bucket("abcd-01").is_err());
+        assert!(validate_timestamp_bucket("2025/01").is_err());
+    }
+
+    #[test]
+    fn test_timestamp_bucket_rejects_invalid_month() {
+        assert!(validate_timestamp_bucket("2025-00").is_err());
+        assert!(validate_timestamp_bucket("2025-13").is_err());
+    }
+
+    #[test]
+    fn test_timestamp_bucket_rejects_year_before_2000() {
+        assert!(validate_timestamp_bucket("1999-12").is_err());
+    }
+
+    // ── validate_base64 ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_base64_accepts_valid_input() {
+        let result = validate_base64("aGVsbG8gd29ybGQ=", "data");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"hello world");
+    }
+
+    #[test]
+    fn test_base64_accepts_unpadded_valid_input() {
+        // "aGk=" is valid standard base64 for "hi"
+        let result = validate_base64("aGk=", "field");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"hi");
+    }
+
+    #[test]
+    fn test_base64_rejects_empty_string() {
+        let result = validate_base64("", "my_field");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("my_field"), "Error should mention field name");
+        assert!(msg.contains("empty"), "Error should mention empty");
+    }
+
+    #[test]
+    fn test_base64_rejects_invalid_characters() {
+        let result = validate_base64("not!valid@base64", "data");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("data"), "Error should mention field name");
+        assert!(msg.contains("base64"), "Error should mention base64");
+    }
+
+    #[test]
+    fn test_base64_rejects_truncated_padding() {
+        // "aGVsbG8" without proper padding
+        let result = validate_base64("aGVsbG8", "field");
+        // Standard base64 with padding required — this should fail
+        assert!(result.is_err());
+    }
+
+    // ── validate_email ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_email_accepts_valid_addresses() {
+        assert!(validate_email("user@example.com").is_ok());
+        assert!(validate_email("a@b.co").is_ok());
+        assert!(validate_email("user+tag@domain.org").is_ok());
+        assert!(validate_email("name@sub.domain.com").is_ok());
+    }
+
+    #[test]
+    fn test_email_rejects_empty_string() {
+        let result = validate_email("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn test_email_rejects_missing_at_symbol() {
+        assert!(validate_email("userexample.com").is_err());
+    }
+
+    #[test]
+    fn test_email_rejects_missing_local_part() {
+        assert!(validate_email("@example.com").is_err());
+    }
+
+    #[test]
+    fn test_email_rejects_missing_domain() {
+        assert!(validate_email("user@").is_err());
+    }
+
+    #[test]
+    fn test_email_rejects_domain_without_dot() {
+        assert!(validate_email("user@localhost").is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `src/validation.rs` with `validate_timestamp_bucket`, `validate_base64`, and `validate_email` helpers, each with comprehensive unit tests (15 total)
- Refactor `handlers/cards.rs`, `handlers/transactions.rs`, and `auth/handler.rs` to use shared validators instead of duplicated inline base64/timestamp logic
- Remove local `DecodedCardFields`, `DecodedTxFields` structs and `decode_card_fields`, `decode_tx_fields`, inline `validate_timestamp_bucket` functions

## Test plan
- [x] All 15 unit tests in `validation.rs` pass (timestamp_bucket, base64, email)
- [x] All 96 existing tests pass — no regressions from refactoring
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)