### PR TITLE
feat(auth): add rate limiting to register and login endpoints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,10 @@ pub enum AppError {
     #[error("{0}")]
     ValidationError(String),
 
+    /// Too many requests — rate limit exceeded.
+    #[error("{0}")]
+    TooManyRequests(String),
+
     /// An unexpected server-side error occurred.
     #[error("{0}")]
     InternalError(String),
@@ -50,6 +54,7 @@ impl AppError {
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
             AppError::Conflict(_) => StatusCode::CONFLICT,
             AppError::ValidationError(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            AppError::TooManyRequests(_) => StatusCode::TOO_MANY_REQUESTS,
             AppError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -62,6 +67,7 @@ impl AppError {
             AppError::Forbidden(_) => "FORBIDDEN",
             AppError::Conflict(_) => "CONFLICT",
             AppError::ValidationError(_) => "VALIDATION_ERROR",
+            AppError::TooManyRequests(_) => "TOO_MANY_REQUESTS",
             AppError::InternalError(_) => "INTERNAL_ERROR",
         }
     }
@@ -145,6 +151,16 @@ mod tests {
         assert_eq!(status, StatusCode::FORBIDDEN);
         assert_eq!(body["error"]["code"], "FORBIDDEN");
         assert_eq!(body["error"]["message"], "not your resource");
+    }
+
+    #[tokio::test]
+    async fn test_too_many_requests_returns_429_with_correct_body() {
+        let (status, body) =
+            parse_response(AppError::TooManyRequests("rate limit exceeded".into())).await;
+
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["error"]["code"], "TOO_MANY_REQUESTS");
+        assert_eq!(body["error"]["message"], "rate limit exceeded");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod db;
 pub mod error;
 pub mod handlers;
+pub mod middleware;
 pub mod models;
 pub mod repositories;
 pub mod router;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+//! HTTP middleware for cross-cutting concerns.
+
+pub mod rate_limit;

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -1,0 +1,181 @@
+//! Fixed-window rate limiter with per-IP tracking.
+//!
+//! Provides a [`RateLimiter`] that tracks request counts per IP address
+//! within a configurable time window, and an axum middleware function
+//! to enforce the limit on specific routes.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+
+use crate::error::AppError;
+
+/// Tracks the request count within the current time window.
+struct WindowEntry {
+    count: u64,
+    window_start: Instant,
+}
+
+/// A fixed-window rate limiter keyed by client IP address.
+///
+/// Each IP gets `max_requests` allowed per `window` duration.
+/// When the window expires, the counter resets automatically.
+#[derive(Clone)]
+pub struct RateLimiter {
+    state: Arc<Mutex<HashMap<IpAddr, WindowEntry>>>,
+    max_requests: u64,
+    window: Duration,
+}
+
+impl RateLimiter {
+    /// Creates a new rate limiter with the given limits.
+    pub fn new(max_requests: u64, window: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            max_requests,
+            window,
+        }
+    }
+
+    /// Checks whether the given IP is within the rate limit.
+    ///
+    /// Increments the request counter and returns `Ok(())` if allowed,
+    /// or `Err(AppError::TooManyRequests)` if the limit is exceeded.
+    pub fn check(&self, ip: IpAddr) -> Result<(), AppError> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
+
+        let entry = state.entry(ip).or_insert(WindowEntry {
+            count: 0,
+            window_start: now,
+        });
+
+        // Reset window if expired
+        if now.duration_since(entry.window_start) >= self.window {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+
+        entry.count += 1;
+
+        if entry.count > self.max_requests {
+            return Err(AppError::TooManyRequests("rate limit exceeded".into()));
+        }
+
+        Ok(())
+    }
+}
+
+/// Extracts the client IP from the request.
+///
+/// Checks `X-Forwarded-For` first (for reverse proxies like Fly.io),
+/// then falls back to `127.0.0.1`.
+fn extract_ip(request: &Request) -> IpAddr {
+    request
+        .headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .and_then(|s| s.trim().parse::<IpAddr>().ok())
+        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+}
+
+/// Axum middleware that enforces a rate limit per client IP.
+///
+/// Apply to routes via `axum::middleware::from_fn_with_state`.
+pub async fn rate_limit(
+    State(limiter): State<RateLimiter>,
+    request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    let ip = extract_ip(&request);
+    limiter.check(ip)?;
+    Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_check_allows_requests_within_limit() {
+        let limiter = RateLimiter::new(3, Duration::from_secs(60));
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_ok());
+    }
+
+    #[test]
+    fn test_check_rejects_requests_over_limit() {
+        let limiter = RateLimiter::new(2, Duration::from_secs(60));
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_ok());
+
+        let result = limiter.check(ip);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("rate limit"),
+            "Error should mention rate limit"
+        );
+    }
+
+    #[test]
+    fn test_check_tracks_ips_independently() {
+        let limiter = RateLimiter::new(1, Duration::from_secs(60));
+        let ip_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let ip_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        assert!(limiter.check(ip_a).is_ok());
+        assert!(limiter.check(ip_b).is_ok());
+
+        // Both exhausted now
+        assert!(limiter.check(ip_a).is_err());
+        assert!(limiter.check(ip_b).is_err());
+    }
+
+    #[test]
+    fn test_check_resets_after_window_expires() {
+        let limiter = RateLimiter::new(1, Duration::from_millis(1));
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_err());
+
+        // Wait for window to expire
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(limiter.check(ip).is_ok(), "Should allow after window reset");
+    }
+
+    #[test]
+    fn test_extract_ip_from_x_forwarded_for() {
+        let request = Request::builder()
+            .header("x-forwarded-for", "203.0.113.50, 70.41.3.18")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let ip = extract_ip(&request);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
+    }
+
+    #[test]
+    fn test_extract_ip_falls_back_to_localhost() {
+        let request = Request::builder().body(axum::body::Body::empty()).unwrap();
+
+        let ip = extract_ip(&request);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,6 +4,8 @@
 //! Keeping routing separate from `main.rs` allows integration tests
 //! to instantiate the full router without binding a real port.
 
+use std::time::Duration;
+
 use axum::Router;
 
 use crate::auth::handler::{login, refresh, register};
@@ -14,14 +16,30 @@ use crate::handlers::test_blob::{create_blob, get_blob};
 use crate::handlers::transactions::{
     create_transaction, delete_transaction, list_transactions, update_transaction,
 };
+use crate::middleware::rate_limit::{rate_limit, RateLimiter};
 use crate::state::AppState;
 
 /// Builds and returns the complete application router with shared state.
 pub fn build_router(state: AppState) -> Router {
+    let register_limiter = RateLimiter::new(5, Duration::from_secs(60));
+    let login_limiter = RateLimiter::new(10, Duration::from_secs(60));
+
     Router::new()
         .route("/health", axum::routing::get(health_check))
-        .route("/auth/register", axum::routing::post(register))
-        .route("/auth/login", axum::routing::post(login))
+        .route(
+            "/auth/register",
+            axum::routing::post(register).layer(axum::middleware::from_fn_with_state(
+                register_limiter,
+                rate_limit,
+            )),
+        )
+        .route(
+            "/auth/login",
+            axum::routing::post(login).layer(axum::middleware::from_fn_with_state(
+                login_limiter,
+                rate_limit,
+            )),
+        )
         .route("/auth/refresh", axum::routing::post(refresh))
         .route("/v1/me", axum::routing::get(me))
         .route(

--- a/tests/rate_limit_test.rs
+++ b/tests/rate_limit_test.rs
@@ -1,0 +1,135 @@
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+/// Generates a unique email for each test run.
+fn unique_email(prefix: &str) -> String {
+    format!("{prefix}+{}@example.com", Uuid::new_v4())
+}
+
+fn register_payload(email: &str) -> serde_json::Value {
+    json!({
+        "email": email,
+        "password": "supersecret123",
+        "wrapped_dek": "aGVsbG8gd29ybGQ=",
+        "dek_salt": "c2FsdHNhbHQ=",
+        "dek_params": "{\"m\":65536,\"t\":3,\"p\":1}"
+    })
+}
+
+// ── Register rate limit ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_register_exceeding_rate_limit_returns_429() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — send 6 requests (limit is 5/min)
+    for i in 0..5 {
+        let email = unique_email(&format!("rl-reg-{i}"));
+        let response = server
+            .post("/auth/register")
+            .json(&register_payload(&email))
+            .await;
+
+        assert_ne!(
+            response.status_code(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Request {i} should not be rate limited"
+        );
+    }
+
+    // 6th request should be rate limited
+    let email = unique_email("rl-reg-over");
+    let response = server
+        .post("/auth/register")
+        .json(&register_payload(&email))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Expected 429 after exceeding register rate limit"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "TOO_MANY_REQUESTS");
+}
+
+// ── Login rate limit ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_login_exceeding_rate_limit_returns_429() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — send 11 requests (limit is 10/min)
+    for i in 0..10 {
+        let response = server
+            .post("/auth/login")
+            .json(&json!({
+                "email": unique_email(&format!("rl-login-{i}")),
+                "password": "whatever"
+            }))
+            .await;
+
+        assert_ne!(
+            response.status_code(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Request {i} should not be rate limited"
+        );
+    }
+
+    // 11th request should be rate limited
+    let response = server
+        .post("/auth/login")
+        .json(&json!({
+            "email": unique_email("rl-login-over"),
+            "password": "whatever"
+        }))
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Expected 429 after exceeding login rate limit"
+    );
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["code"], "TOO_MANY_REQUESTS");
+}
+
+// ── Rate limits are independent per endpoint ────────────────────────────────
+
+#[tokio::test]
+async fn test_register_rate_limit_does_not_affect_login() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Exhaust register limit (5 requests)
+    for i in 0..5 {
+        let email = unique_email(&format!("rl-cross-reg-{i}"));
+        server
+            .post("/auth/register")
+            .json(&register_payload(&email))
+            .await;
+    }
+
+    // Act — login should still work (different limiter)
+    let response = server
+        .post("/auth/login")
+        .json(&json!({
+            "email": unique_email("rl-cross-login"),
+            "password": "whatever"
+        }))
+        .await;
+
+    // Assert — should get 401 (invalid creds), NOT 429
+    assert_eq!(
+        response.status_code(),
+        StatusCode::UNAUTHORIZED,
+        "Login rate limit should be independent from register"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `TooManyRequests` variant to `AppError` (maps to 429 status code)
- Implement `RateLimiter` with fixed-window per-IP tracking in `src/middleware/rate_limit.rs`
- Apply rate limits: `POST /auth/register` at 5 req/min, `POST /auth/login` at 10 req/min
- Extract client IP from `X-Forwarded-For` header (Fly.io compatible) with localhost fallback

## Test plan
- [x] 6 unit tests for `RateLimiter` (within limit, over limit, independent IPs, window reset, IP extraction)
- [x] 1 unit test for `TooManyRequests` error variant (429 + correct body)
- [x] 3 integration tests (register 429, login 429, independent limiters)
- [x] All 106 tests pass — no regressions
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)