### PR TITLE
feat(api): configure CORS middleware with env-based allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ JWT_EXPIRATION_HOURS=24
 HOST=0.0.0.0
 PORT=8080
 
+# CORS (comma-separated origins, defaults to http://localhost:3000)
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+
 # Logging
 RUST_LOG=info,cardpulse_api=debug

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,10 @@ pub struct AppConfig {
     pub jwt_secret: String,
     /// Token lifetime in hours (`JWT_EXPIRATION_HOURS`, default `24`).
     pub jwt_expiration_hours: u64,
+    /// Comma-separated list of allowed CORS origins (`CORS_ALLOWED_ORIGINS`).
+    ///
+    /// Defaults to `http://localhost:3000` for local development.
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl AppConfig {
@@ -38,6 +42,57 @@ impl AppConfig {
                 .unwrap_or_else(|_| "24".to_string())
                 .parse()
                 .expect("JWT_EXPIRATION_HOURS must be a valid u64"),
+            cors_allowed_origins: std::env::var("CORS_ALLOWED_ORIGINS")
+                .unwrap_or_else(|_| "http://localhost:3000".to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cors_origins_splits_comma_separated_values() {
+        let input = "https://app.example.com, https://staging.example.com";
+        let origins: Vec<String> = input
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        assert_eq!(origins.len(), 2);
+        assert_eq!(origins[0], "https://app.example.com");
+        assert_eq!(origins[1], "https://staging.example.com");
+    }
+
+    #[test]
+    fn test_parse_cors_origins_handles_single_value() {
+        let input = "https://app.example.com";
+        let origins: Vec<String> = input
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0], "https://app.example.com");
+    }
+
+    #[test]
+    fn test_parse_cors_origins_filters_empty_entries() {
+        let input = "https://app.example.com,,, ";
+        let origins: Vec<String> = input
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0], "https://app.example.com");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,12 @@ async fn main() {
         .await
         .expect("failed to connect to database");
 
-    let state = AppState::new(pool, config.jwt_secret, config.jwt_expiration_hours);
+    let state = AppState::new(
+        pool,
+        config.jwt_secret,
+        config.jwt_expiration_hours,
+        config.cors_allowed_origins,
+    );
     let app = build_router(state);
 
     let listener = TcpListener::bind(&addr)

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,7 +6,9 @@
 
 use std::time::Duration;
 
+use axum::http::{header, Method};
 use axum::Router;
+use tower_http::cors::CorsLayer;
 
 use crate::auth::handler::{login, refresh, register};
 use crate::handlers::cards::{create_card, delete_card, list_cards, update_card};
@@ -19,8 +21,21 @@ use crate::handlers::transactions::{
 use crate::middleware::rate_limit::{rate_limit, RateLimiter};
 use crate::state::AppState;
 
+/// Builds a [`CorsLayer`] from the allowed origins list.
+///
+/// Allows GET, POST, PUT, DELETE methods and Authorization + Content-Type headers.
+fn build_cors_layer(origins: &[String]) -> CorsLayer {
+    let allowed_origins: Vec<_> = origins.iter().filter_map(|o| o.parse().ok()).collect();
+
+    CorsLayer::new()
+        .allow_origin(allowed_origins)
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
+}
+
 /// Builds and returns the complete application router with shared state.
 pub fn build_router(state: AppState) -> Router {
+    let cors = build_cors_layer(&state.cors_allowed_origins);
     let register_limiter = RateLimiter::new(5, Duration::from_secs(60));
     let login_limiter = RateLimiter::new(10, Duration::from_secs(60));
 
@@ -60,5 +75,6 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route("/v1/test", axum::routing::post(create_blob))
         .route("/v1/test/:id", axum::routing::get(get_blob))
+        .layer(cors)
         .with_state(state)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,15 +13,23 @@ pub struct AppState {
     pub jwt_secret: String,
     /// JWT lifetime in hours.
     pub jwt_expiration_hours: u64,
+    /// Allowed CORS origins for the API.
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl AppState {
     /// Creates a new [`AppState`].
-    pub fn new(pool: PgPool, jwt_secret: String, jwt_expiration_hours: u64) -> Self {
+    pub fn new(
+        pool: PgPool,
+        jwt_secret: String,
+        jwt_expiration_hours: u64,
+        cors_allowed_origins: Vec<String>,
+    ) -> Self {
         Self {
             pool,
             jwt_secret,
             jwt_expiration_hours,
+            cors_allowed_origins,
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,7 +21,12 @@ pub async fn test_pool() -> PgPool {
 
 /// Spawns an in-process test server backed by the given pool.
 pub async fn spawn_test_app_with_state(pool: PgPool) -> TestServer {
-    let state = AppState::new(pool, TEST_JWT_SECRET.to_string(), TEST_JWT_EXPIRATION_HOURS);
+    let state = AppState::new(
+        pool,
+        TEST_JWT_SECRET.to_string(),
+        TEST_JWT_EXPIRATION_HOURS,
+        vec!["http://localhost:3000".to_string()],
+    );
     let app = build_router(state);
     TestServer::new(app).expect("failed to create test server")
 }

--- a/tests/cors_test.rs
+++ b/tests/cors_test.rs
@@ -1,0 +1,129 @@
+mod common;
+
+use axum::http::{HeaderValue, StatusCode};
+
+// ── Allowed origin ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_cors_preflight_with_allowed_origin_returns_200() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — OPTIONS preflight from allowed origin
+    let response = server
+        .method(axum::http::Method::OPTIONS, "/auth/login")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("http://localhost:3000"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_METHOD,
+            HeaderValue::from_static("POST"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_HEADERS,
+            HeaderValue::from_static("authorization,content-type"),
+        )
+        .await;
+
+    // Assert
+    assert_eq!(
+        response.status_code(),
+        StatusCode::OK,
+        "Preflight from allowed origin should succeed"
+    );
+    let acao = response.header("access-control-allow-origin");
+    assert_eq!(acao, "http://localhost:3000");
+}
+
+#[tokio::test]
+async fn test_cors_allows_get_post_put_delete_methods() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .method(axum::http::Method::OPTIONS, "/v1/cards")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("http://localhost:3000"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_METHOD,
+            HeaderValue::from_static("PUT"),
+        )
+        .await;
+
+    // Assert
+    let methods = response.header("access-control-allow-methods");
+    let methods_str = methods.to_str().unwrap();
+    for method in ["GET", "POST", "PUT", "DELETE"] {
+        assert!(
+            methods_str.contains(method),
+            "CORS should allow {method}, got: {methods_str}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_cors_allows_authorization_and_content_type_headers() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act
+    let response = server
+        .method(axum::http::Method::OPTIONS, "/v1/cards")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("http://localhost:3000"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_METHOD,
+            HeaderValue::from_static("POST"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_HEADERS,
+            HeaderValue::from_static("authorization,content-type"),
+        )
+        .await;
+
+    // Assert
+    let headers = response.header("access-control-allow-headers");
+    let headers_str = headers.to_str().unwrap().to_lowercase();
+    assert!(
+        headers_str.contains("authorization"),
+        "CORS should allow authorization header, got: {headers_str}"
+    );
+    assert!(
+        headers_str.contains("content-type"),
+        "CORS should allow content-type header, got: {headers_str}"
+    );
+}
+
+// ── Disallowed origin ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_cors_preflight_with_disallowed_origin_omits_acao_header() {
+    // Arrange
+    let server = common::spawn_test_app().await;
+
+    // Act — OPTIONS preflight from a non-allowed origin
+    let response = server
+        .method(axum::http::Method::OPTIONS, "/auth/login")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("https://evil.example.com"),
+        )
+        .add_header(
+            axum::http::header::ACCESS_CONTROL_REQUEST_METHOD,
+            HeaderValue::from_static("POST"),
+        )
+        .await;
+
+    // Assert — no access-control-allow-origin header should be present
+    let acao = response.maybe_header("access-control-allow-origin");
+    assert!(
+        acao.is_none(),
+        "Disallowed origin should not receive ACAO header"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `CORS_ALLOWED_ORIGINS` env var to `AppConfig` (comma-separated, defaults to `http://localhost:3000` for dev)
- Configure `tower_http::cors::CorsLayer` in the router with allowed methods (GET, POST, PUT, DELETE) and headers (Authorization, Content-Type)
- Pass allowed origins through `AppState` so the router can build the CORS layer
- Update `.env.example` with the new variable

## Test plan
- [x] 3 unit tests for CORS origin parsing (comma-separated, single value, empty entries)
- [x] 4 integration tests (preflight with allowed origin, allowed methods, allowed headers, disallowed origin)
- [x] All 113 tests pass — no regressions
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)