### PR TITLE
feat(crypto): implement client-side decryption with Web Crypto API

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -27,7 +27,8 @@
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -827,6 +828,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1119,6 +1127,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1485,6 +1511,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1547,6 +1686,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1643,6 +1792,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1783,6 +1942,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1981,6 +2147,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1989,6 +2165,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2673,6 +2859,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2755,6 +2952,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2975,6 +3179,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2983,6 +3194,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3029,6 +3254,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3043,6 +3285,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3241,6 +3493,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3255,6 +3589,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -29,6 +31,7 @@
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.1"
   }
 }

--- a/dashboard/src/lib/crypto.test.ts
+++ b/dashboard/src/lib/crypto.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveKey,
+  unwrapDek,
+  decrypt,
+  base64ToBytes,
+  bytesToBase64,
+} from "./crypto";
+
+// ═══════════════════════════════════════════════════════════════════════
+// Test vectors generated with Web Crypto API — known-good values
+// ═══════════════════════════════════════════════════════════════════════
+
+// To generate these vectors, we use the same crypto flow as the iOS client:
+//   1. PBKDF2(password, salt, iterations) → unwrap key
+//   2. AES-GCM-encrypt(DEK, unwrap key, iv) → wrapped_dek
+//   3. AES-GCM-encrypt(plaintext, DEK, iv) → encrypted_data + auth_tag
+
+describe("base64ToBytes", () => {
+  it("decodes a valid base64 string to Uint8Array", () => {
+    // "hello" in base64 is "aGVsbG8="
+    const bytes = base64ToBytes("aGVsbG8=");
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(bytes)).toBe("hello");
+  });
+
+  it("handles empty base64 string", () => {
+    const bytes = base64ToBytes("");
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(0);
+  });
+});
+
+describe("bytesToBase64", () => {
+  it("encodes Uint8Array to base64 string", () => {
+    const bytes = new TextEncoder().encode("hello");
+    expect(bytesToBase64(bytes)).toBe("aGVsbG8=");
+  });
+
+  it("handles empty Uint8Array", () => {
+    expect(bytesToBase64(new Uint8Array(0))).toBe("");
+  });
+});
+
+describe("deriveKey", () => {
+  it("derives a CryptoKey from password, salt, and params", async () => {
+    const password = "test-password-123";
+    const salt = bytesToBase64(new TextEncoder().encode("test-salt-value!"));
+    const params = { iterations: 1000 };
+
+    const key = await deriveKey(password, salt, params);
+
+    expect(key).toBeInstanceOf(CryptoKey);
+    expect(key.algorithm).toMatchObject({ name: "AES-GCM", length: 256 });
+    expect(key.usages).toContain("decrypt");
+    // Key should not be extractable for security
+    expect(key.extractable).toBe(false);
+  });
+
+  it("produces deterministic output for same inputs", async () => {
+    const password = "deterministic-test";
+    const salt = bytesToBase64(new TextEncoder().encode("same-salt-1234!!"));
+    const params = { iterations: 1000 };
+
+    // Derive two keys independently — they should be equivalent
+    await deriveKey(password, salt, params);
+    const key2 = await deriveKey(password, salt, params);
+
+    // Since keys aren't extractable, we verify by encrypting
+    // and then decrypting with the independently derived key
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const data = new TextEncoder().encode("test data");
+
+    // Derive an encrypt-capable key for this test
+    const encryptKey = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt: base64ToBytes(salt).buffer as ArrayBuffer,
+        iterations: 1000,
+        hash: "SHA-256",
+      },
+      await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(password),
+        "PBKDF2",
+        false,
+        ["deriveKey"]
+      ),
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      encryptKey,
+      data
+    );
+
+    // Decrypt with key2 (derived independently)
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      key2,
+      encrypted
+    );
+
+    expect(new TextDecoder().decode(decrypted)).toBe("test data");
+  });
+
+  it("uses default iterations when not specified", async () => {
+    const password = "test-password";
+    const salt = bytesToBase64(new TextEncoder().encode("salt-for-default"));
+    const params = {};
+
+    const key = await deriveKey(password, salt, params);
+    expect(key).toBeInstanceOf(CryptoKey);
+  });
+
+  it("produces different keys for different passwords", async () => {
+    const salt = bytesToBase64(new TextEncoder().encode("shared-salt-val!"));
+    const params = { iterations: 1000 };
+
+    const key2 = await deriveKey("password-two", salt, params);
+
+    // Encrypt with password-one, try to decrypt with key2 (password-two) — should fail
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const data = new TextEncoder().encode("secret");
+
+    // Derive an encrypt-capable key for password-one
+    const encKey = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt: base64ToBytes(salt).buffer as ArrayBuffer,
+        iterations: 1000,
+        hash: "SHA-256",
+      },
+      await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode("password-one"),
+        "PBKDF2",
+        false,
+        ["deriveKey"]
+      ),
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      encKey,
+      data
+    );
+
+    await expect(
+      crypto.subtle.decrypt(
+        { name: "AES-GCM", iv, tagLength: 128 },
+        key2,
+        encrypted
+      )
+    ).rejects.toThrow();
+  });
+});
+
+describe("unwrapDek", () => {
+  it("unwraps a DEK encrypted with AES-GCM", async () => {
+    // Setup: create a DEK, wrap it, then unwrap
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const password = "unwrap-test-password";
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const saltB64 = bytesToBase64(salt);
+    const params = { iterations: 1000 };
+
+    // Derive the wrapping key
+    const passwordKey = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(password),
+      "PBKDF2",
+      false,
+      ["deriveKey"]
+    );
+
+    const wrapKey = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: 1000,
+        hash: "SHA-256",
+      },
+      passwordKey,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    // Wrap the DEK: IV (12) + ciphertext + tag
+    const wrapIv = crypto.getRandomValues(new Uint8Array(12));
+    const wrapped = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: wrapIv, tagLength: 128 },
+      wrapKey,
+      dek
+    );
+
+    // Build wrapped_dek = IV + encrypted
+    const wrappedDek = new Uint8Array(12 + wrapped.byteLength);
+    wrappedDek.set(wrapIv, 0);
+    wrappedDek.set(new Uint8Array(wrapped), 12);
+    const wrappedDekB64 = bytesToBase64(wrappedDek);
+
+    // Act: derive key and unwrap
+    const derivedKey = await deriveKey(password, saltB64, params);
+    const unwrappedDek = await unwrapDek(wrappedDekB64, derivedKey);
+
+    // Assert: unwrapped DEK matches original
+    expect(unwrappedDek).toBeInstanceOf(Uint8Array);
+    expect(unwrappedDek.length).toBe(32);
+    expect(Array.from(unwrappedDek)).toEqual(Array.from(dek));
+  });
+
+  it("throws CryptoError on wrong password", async () => {
+    // Wrap a DEK with one password
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const saltB64 = bytesToBase64(salt);
+
+    const passwordKey = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("correct-password"),
+      "PBKDF2",
+      false,
+      ["deriveKey"]
+    );
+
+    const wrapKey = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: 1000,
+        hash: "SHA-256",
+      },
+      passwordKey,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const wrapIv = crypto.getRandomValues(new Uint8Array(12));
+    const wrapped = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: wrapIv, tagLength: 128 },
+      wrapKey,
+      dek
+    );
+
+    const wrappedDek = new Uint8Array(12 + wrapped.byteLength);
+    wrappedDek.set(wrapIv, 0);
+    wrappedDek.set(new Uint8Array(wrapped), 12);
+    const wrappedDekB64 = bytesToBase64(wrappedDek);
+
+    // Try to unwrap with wrong password
+    const wrongKey = await deriveKey("wrong-password", saltB64, {
+      iterations: 1000,
+    });
+
+    await expect(unwrapDek(wrappedDekB64, wrongKey)).rejects.toThrow(
+      /wrong password|decryption failed/i
+    );
+  });
+
+  it("throws on malformed wrapped DEK (too short)", async () => {
+    const salt = bytesToBase64(crypto.getRandomValues(new Uint8Array(16)));
+    const key = await deriveKey("password", salt, { iterations: 1000 });
+
+    // Only 10 bytes — shorter than required 12-byte IV
+    const shortData = bytesToBase64(new Uint8Array(10));
+
+    await expect(unwrapDek(shortData, key)).rejects.toThrow();
+  });
+});
+
+describe("decrypt", () => {
+  it("decrypts AES-256-GCM encrypted data", async () => {
+    const plaintext = "Mercado Extra R$ 35,94";
+
+    // Generate a DEK and encrypt the plaintext
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const importedKey = await crypto.subtle.importKey(
+      "raw",
+      dek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      importedKey,
+      new TextEncoder().encode(plaintext)
+    );
+
+    // Split into ciphertext + auth tag (last 16 bytes)
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertext = encBytes.slice(0, encBytes.length - 16);
+    const authTag = encBytes.slice(encBytes.length - 16);
+
+    const ciphertextB64 = bytesToBase64(ciphertext);
+    const ivB64 = bytesToBase64(iv);
+    const authTagB64 = bytesToBase64(authTag);
+
+    // Act
+    const decrypted = await decrypt(ciphertextB64, ivB64, authTagB64, dek);
+
+    // Assert
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("decrypts UTF-8 content with special characters", async () => {
+    const plaintext = "Padaria São João — R$ 12,50 ☕";
+
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const importedKey = await crypto.subtle.importKey(
+      "raw",
+      dek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      importedKey,
+      new TextEncoder().encode(plaintext)
+    );
+
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertextB64 = bytesToBase64(encBytes.slice(0, encBytes.length - 16));
+    const ivB64 = bytesToBase64(iv);
+    const authTagB64 = bytesToBase64(encBytes.slice(encBytes.length - 16));
+
+    const decrypted = await decrypt(ciphertextB64, ivB64, authTagB64, dek);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("decrypts JSON content (card/transaction data)", async () => {
+    const jsonData = JSON.stringify({
+      merchant: "Shell",
+      amount: 250.0,
+      currency: "BRL",
+    });
+
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const importedKey = await crypto.subtle.importKey(
+      "raw",
+      dek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      importedKey,
+      new TextEncoder().encode(jsonData)
+    );
+
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertextB64 = bytesToBase64(encBytes.slice(0, encBytes.length - 16));
+    const ivB64 = bytesToBase64(iv);
+    const authTagB64 = bytesToBase64(encBytes.slice(encBytes.length - 16));
+
+    const decrypted = await decrypt(ciphertextB64, ivB64, authTagB64, dek);
+    expect(JSON.parse(decrypted)).toEqual({
+      merchant: "Shell",
+      amount: 250.0,
+      currency: "BRL",
+    });
+  });
+
+  it("throws on tampered ciphertext", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const importedKey = await crypto.subtle.importKey(
+      "raw",
+      dek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      importedKey,
+      new TextEncoder().encode("original data")
+    );
+
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertext = encBytes.slice(0, encBytes.length - 16);
+    const authTag = encBytes.slice(encBytes.length - 16);
+
+    // Tamper with ciphertext
+    ciphertext[0] ^= 0xff;
+
+    await expect(
+      decrypt(bytesToBase64(ciphertext), bytesToBase64(iv), bytesToBase64(authTag), dek)
+    ).rejects.toThrow(/decryption failed/i);
+  });
+
+  it("throws on wrong DEK", async () => {
+    const correctDek = crypto.getRandomValues(new Uint8Array(32));
+    const wrongDek = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    const importedKey = await crypto.subtle.importKey(
+      "raw",
+      correctDek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv, tagLength: 128 },
+      importedKey,
+      new TextEncoder().encode("secret data")
+    );
+
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertextB64 = bytesToBase64(encBytes.slice(0, encBytes.length - 16));
+    const ivB64 = bytesToBase64(iv);
+    const authTagB64 = bytesToBase64(encBytes.slice(encBytes.length - 16));
+
+    await expect(
+      decrypt(ciphertextB64, ivB64, authTagB64, wrongDek)
+    ).rejects.toThrow(/decryption failed/i);
+  });
+});
+
+describe("end-to-end: wrap → unwrap → encrypt → decrypt", () => {
+  it("completes full crypto roundtrip", async () => {
+    const masterPassword = "minha-senha-segura-123";
+    const plaintext = "Nubank Mastercard ...4567 — R$ 89,90";
+
+    // 1. Generate DEK
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+
+    // 2. Generate salt and derive wrapping key
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const saltB64 = bytesToBase64(salt);
+    const params = { iterations: 1000 };
+
+    const passwordKey = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(masterPassword),
+      "PBKDF2",
+      false,
+      ["deriveKey"]
+    );
+
+    const wrapKey = await crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: 1000,
+        hash: "SHA-256",
+      },
+      passwordKey,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+
+    // 3. Wrap the DEK
+    const wrapIv = crypto.getRandomValues(new Uint8Array(12));
+    const wrapped = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: wrapIv, tagLength: 128 },
+      wrapKey,
+      dek
+    );
+
+    const wrappedDek = new Uint8Array(12 + wrapped.byteLength);
+    wrappedDek.set(wrapIv, 0);
+    wrappedDek.set(new Uint8Array(wrapped), 12);
+    const wrappedDekB64 = bytesToBase64(wrappedDek);
+
+    // 4. Encrypt plaintext with DEK
+    const encIv = crypto.getRandomValues(new Uint8Array(12));
+    const encKey = await crypto.subtle.importKey(
+      "raw",
+      dek,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt"]
+    );
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: encIv, tagLength: 128 },
+      encKey,
+      new TextEncoder().encode(plaintext)
+    );
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertextB64 = bytesToBase64(encBytes.slice(0, encBytes.length - 16));
+    const encIvB64 = bytesToBase64(encIv);
+    const authTagB64 = bytesToBase64(encBytes.slice(encBytes.length - 16));
+
+    // ── Now simulate the dashboard flow ──
+
+    // 5. Derive key from master password
+    const derivedKey = await deriveKey(masterPassword, saltB64, params);
+
+    // 6. Unwrap the DEK
+    const unwrappedDek = await unwrapDek(wrappedDekB64, derivedKey);
+
+    // 7. Decrypt the data
+    const decrypted = await decrypt(ciphertextB64, encIvB64, authTagB64, unwrappedDek);
+
+    expect(decrypted).toBe(plaintext);
+  });
+});

--- a/dashboard/src/lib/crypto.ts
+++ b/dashboard/src/lib/crypto.ts
@@ -1,0 +1,203 @@
+/**
+ * Client-side cryptography module using Web Crypto API.
+ *
+ * Implements the zero-knowledge decryption flow:
+ *   1. Derive an unwrap key from master password + salt via PBKDF2
+ *   2. Unwrap (decrypt) the DEK using AES-256-GCM
+ *   3. Decrypt card/transaction data using the DEK with AES-256-GCM
+ *
+ * No external dependencies — uses only the browser's native Web Crypto API.
+ */
+
+/** Default number of PBKDF2 iterations if not specified in dek_params. */
+const DEFAULT_ITERATIONS = 600000;
+
+/** AES-GCM initialization vector length in bytes. */
+const IV_LENGTH = 12;
+
+/** AES-GCM authentication tag length in bits. */
+const TAG_LENGTH_BITS = 128;
+
+
+/** Parameters for DEK derivation via PBKDF2. */
+export interface DekParams {
+  iterations?: number;
+}
+
+/** Custom error for cryptographic operation failures. */
+export class CryptoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CryptoError";
+  }
+}
+
+/**
+ * Decodes a base64-encoded string into a Uint8Array.
+ *
+ * Uses the browser's native `atob` for decoding.
+ */
+export function base64ToBytes(base64: string): Uint8Array {
+  if (base64 === "") return new Uint8Array(0);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Encodes a Uint8Array into a base64 string.
+ *
+ * Uses the browser's native `btoa` for encoding.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Derives a CryptoKey from a master password and salt using PBKDF2-SHA256.
+ *
+ * The derived key is suitable for unwrapping (decrypting) the user's DEK.
+ * Uses PBKDF2 because Web Crypto API does not support Argon2id.
+ *
+ * @param password - The user's master password
+ * @param saltBase64 - Base64-encoded salt (from server's dek_salt)
+ * @param params - Derivation parameters (iterations count)
+ * @returns A non-extractable CryptoKey for AES-256-GCM decryption
+ */
+export async function deriveKey(
+  password: string,
+  saltBase64: string,
+  params: DekParams
+): Promise<CryptoKey> {
+  const salt = base64ToBytes(saltBase64);
+  const iterations = params.iterations ?? DEFAULT_ITERATIONS;
+
+  const passwordKey = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: salt.buffer as ArrayBuffer,
+      iterations,
+      hash: "SHA-256",
+    },
+    passwordKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"]
+  );
+}
+
+/**
+ * Unwraps (decrypts) the Data Encryption Key using a derived key.
+ *
+ * The wrapped DEK format is: [12-byte IV] + [ciphertext + 16-byte auth tag].
+ * This matches the format produced by the iOS Scriptable client.
+ *
+ * @param wrappedDekBase64 - Base64-encoded wrapped DEK from the server
+ * @param derivedKey - CryptoKey derived from master password via `deriveKey()`
+ * @returns The raw DEK as a Uint8Array (32 bytes for AES-256)
+ *
+ * @throws {CryptoError} If the wrapped DEK is too short or decryption fails
+ *   (wrong password produces a decryption failure)
+ */
+export async function unwrapDek(
+  wrappedDekBase64: string,
+  derivedKey: CryptoKey
+): Promise<Uint8Array> {
+  const wrappedBytes = base64ToBytes(wrappedDekBase64);
+
+  if (wrappedBytes.length <= IV_LENGTH) {
+    throw new CryptoError(
+      "Decryption failed: wrapped DEK is too short"
+    );
+  }
+
+  const iv = wrappedBytes.slice(0, IV_LENGTH);
+  const ciphertext = wrappedBytes.slice(IV_LENGTH);
+
+  try {
+    const dekBytes = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer, tagLength: TAG_LENGTH_BITS },
+      derivedKey,
+      ciphertext.buffer as ArrayBuffer
+    );
+
+    return new Uint8Array(dekBytes);
+  } catch {
+    throw new CryptoError(
+      "Decryption failed: wrong password or corrupted data"
+    );
+  }
+}
+
+/**
+ * Decrypts AES-256-GCM encrypted data using the DEK.
+ *
+ * The encrypted data format matches the CardPulse convention:
+ * - `ciphertext`: the encrypted content (without auth tag)
+ * - `iv`: 12-byte initialization vector
+ * - `authTag`: 16-byte authentication tag
+ *
+ * All inputs are base64-encoded. The ciphertext and auth tag are
+ * concatenated before decryption, as Web Crypto API expects them together.
+ *
+ * @param ciphertextBase64 - Base64-encoded ciphertext (without auth tag)
+ * @param ivBase64 - Base64-encoded 12-byte IV
+ * @param authTagBase64 - Base64-encoded 16-byte auth tag
+ * @param dek - Raw DEK as Uint8Array (32 bytes)
+ * @returns Decrypted plaintext as a UTF-8 string
+ *
+ * @throws {CryptoError} If decryption fails (wrong key, tampered data, etc.)
+ */
+export async function decrypt(
+  ciphertextBase64: string,
+  ivBase64: string,
+  authTagBase64: string,
+  dek: Uint8Array
+): Promise<string> {
+  const ciphertext = base64ToBytes(ciphertextBase64);
+  const iv = base64ToBytes(ivBase64);
+  const authTag = base64ToBytes(authTagBase64);
+
+  // Web Crypto expects ciphertext + authTag concatenated
+  const combined = new Uint8Array(ciphertext.length + authTag.length);
+  combined.set(ciphertext, 0);
+  combined.set(authTag, ciphertext.length);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    dek.buffer as ArrayBuffer,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"]
+  );
+
+  try {
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer, tagLength: TAG_LENGTH_BITS },
+      key,
+      combined.buffer as ArrayBuffer
+    );
+
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    throw new CryptoError(
+      "Decryption failed: wrong key or tampered data"
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `lib/crypto.ts` module with zero-dependency AES-256-GCM decryption using the browser's native Web Crypto API
- Implement `deriveKey(password, salt, params)` — PBKDF2-SHA256 key derivation
- Implement `unwrapDek(wrappedDek, derivedKey)` — decrypts the DEK from server's wrapped format (IV + ciphertext + tag)
- Implement `decrypt(ciphertext, iv, authTag, dek)` — AES-256-GCM decryption for card/transaction data
- Add `base64ToBytes` / `bytesToBase64` helper utilities
- Add `CryptoError` custom error class for graceful failure handling
- Configure Vitest as test framework with `npm test` and `npm run test:watch` scripts
- 17 unit tests covering all acceptance criteria including end-to-end roundtrip

## Test plan
- [x] `deriveKey` produces deterministic CryptoKey from same inputs
- [x] `deriveKey` produces different keys for different passwords
- [x] `unwrapDek` correctly unwraps a wrapped DEK
- [x] `unwrapDek` throws `CryptoError` on wrong password
- [x] `unwrapDek` throws on malformed (too short) wrapped DEK
- [x] `decrypt` decrypts AES-256-GCM encrypted data
- [x] `decrypt` handles UTF-8 with special characters
- [x] `decrypt` handles JSON content
- [x] `decrypt` throws on tampered ciphertext
- [x] `decrypt` throws on wrong DEK
- [x] Full end-to-end roundtrip: wrap → unwrap → encrypt → decrypt
- [x] ESLint clean
- [x] TypeScript compilation clean

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)