### PR TITLE
feat(dashboard): implement client-side filters and search

### DIFF
--- a/dashboard/src/components/FilterBar.tsx
+++ b/dashboard/src/components/FilterBar.tsx
@@ -1,0 +1,197 @@
+/**
+ * Filter bar for transaction search and filtering.
+ *
+ * All filtering happens on decrypted data client-side.
+ * The server never sees filter criteria.
+ */
+
+import type { TransactionFilters } from "../lib/filters";
+import type { DecryptedTransaction } from "../types/dashboard";
+
+interface FilterBarProps {
+  filters: TransactionFilters;
+  onFilterChange: <K extends keyof TransactionFilters>(
+    key: K,
+    value: TransactionFilters[K]
+  ) => void;
+  onClear: () => void;
+  hasActiveFilters: boolean;
+  transactions: DecryptedTransaction[];
+}
+
+/** Extracts unique sorted values from a field across transactions. */
+function uniqueValues(
+  transactions: DecryptedTransaction[],
+  field: keyof DecryptedTransaction
+): string[] {
+  const values = new Set(transactions.map((t) => String(t[field])));
+  return Array.from(values).sort();
+}
+
+export function FilterBar({
+  filters,
+  onFilterChange,
+  onClear,
+  hasActiveFilters,
+  transactions,
+}: FilterBarProps) {
+  const months = uniqueValues(transactions, "timestamp_bucket");
+  const categories = uniqueValues(transactions, "category");
+  const cardIds = uniqueValues(transactions, "card_id");
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-wrap items-end gap-3">
+        {/* Search */}
+        <div className="min-w-[200px] flex-1">
+          <label
+            htmlFor="search"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Search
+          </label>
+          <input
+            id="search"
+            type="text"
+            value={filters.search ?? ""}
+            onChange={(e) => onFilterChange("search", e.target.value || undefined)}
+            placeholder="Merchant name..."
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* Month */}
+        <div className="min-w-[130px]">
+          <label
+            htmlFor="month"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Month
+          </label>
+          <select
+            id="month"
+            value={filters.month ?? ""}
+            onChange={(e) => onFilterChange("month", e.target.value || undefined)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          >
+            <option value="">All months</option>
+            {months.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Card */}
+        <div className="min-w-[130px]">
+          <label
+            htmlFor="card"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Card
+          </label>
+          <select
+            id="card"
+            value={filters.cardId ?? ""}
+            onChange={(e) =>
+              onFilterChange("cardId", e.target.value || undefined)
+            }
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          >
+            <option value="">All cards</option>
+            {cardIds.map((c) => (
+              <option key={c} value={c}>
+                {c.slice(0, 8)}...
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Category */}
+        <div className="min-w-[130px]">
+          <label
+            htmlFor="category"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Category
+          </label>
+          <select
+            id="category"
+            value={filters.category ?? ""}
+            onChange={(e) =>
+              onFilterChange("category", e.target.value || undefined)
+            }
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          >
+            <option value="">All categories</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Amount range */}
+        <div className="min-w-[90px]">
+          <label
+            htmlFor="amountMin"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Min R$
+          </label>
+          <input
+            id="amountMin"
+            type="number"
+            min="0"
+            step="0.01"
+            value={filters.amountMin ?? ""}
+            onChange={(e) =>
+              onFilterChange(
+                "amountMin",
+                e.target.value ? Number(e.target.value) : undefined
+              )
+            }
+            placeholder="0"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+        </div>
+
+        <div className="min-w-[90px]">
+          <label
+            htmlFor="amountMax"
+            className="block text-xs font-medium text-gray-500"
+          >
+            Max R$
+          </label>
+          <input
+            id="amountMax"
+            type="number"
+            min="0"
+            step="0.01"
+            value={filters.amountMax ?? ""}
+            onChange={(e) =>
+              onFilterChange(
+                "amountMax",
+                e.target.value ? Number(e.target.value) : undefined
+              )
+            }
+            placeholder="999"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* Clear filters */}
+        {hasActiveFilters && (
+          <button
+            onClick={onClear}
+            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/hooks/useFilters.ts
+++ b/dashboard/src/hooks/useFilters.ts
@@ -1,0 +1,68 @@
+/**
+ * Hook for managing transaction filters synced with URL query params.
+ *
+ * Reads initial filter state from the URL and updates the URL when
+ * filters change — enabling shareable/bookmarkable filter states.
+ */
+
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  type TransactionFilters,
+  parseFiltersFromParams,
+  filtersToParams,
+} from "../lib/filters";
+
+/** Hook return type with current filters and update functions. */
+export interface UseFiltersReturn {
+  filters: TransactionFilters;
+  setFilters: (filters: TransactionFilters) => void;
+  updateFilter: <K extends keyof TransactionFilters>(
+    key: K,
+    value: TransactionFilters[K]
+  ) => void;
+  clearFilters: () => void;
+  hasActiveFilters: boolean;
+}
+
+/** Manages filter state synchronized with URL search params. */
+export function useFilters(): UseFiltersReturn {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters = useMemo(
+    () => parseFiltersFromParams(searchParams),
+    [searchParams]
+  );
+
+  const setFilters = useCallback(
+    (newFilters: TransactionFilters) => {
+      const params = filtersToParams(newFilters);
+      setSearchParams(params, { replace: true });
+    },
+    [setSearchParams]
+  );
+
+  const updateFilter = useCallback(
+    <K extends keyof TransactionFilters>(
+      key: K,
+      value: TransactionFilters[K]
+    ) => {
+      const updated = { ...filters };
+      if (value === undefined || value === "") {
+        delete updated[key];
+      } else {
+        updated[key] = value;
+      }
+      setFilters(updated);
+    },
+    [filters, setFilters]
+  );
+
+  const clearFilters = useCallback(() => {
+    setSearchParams({}, { replace: true });
+  }, [setSearchParams]);
+
+  const hasActiveFilters = Object.keys(filters).length > 0;
+
+  return { filters, setFilters, updateFilter, clearFilters, hasActiveFilters };
+}

--- a/dashboard/src/lib/filters.test.ts
+++ b/dashboard/src/lib/filters.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  type TransactionFilters,
+  filterTransactions,
+  parseFiltersFromParams,
+  filtersToParams,
+} from "./filters";
+import type { DecryptedTransaction } from "../types/dashboard";
+
+function makeTx(
+  overrides: Partial<DecryptedTransaction> = {}
+): DecryptedTransaction {
+  return {
+    id: "tx-1",
+    card_id: "card-1",
+    timestamp_bucket: "2026-03",
+    created_at: "2026-03-15T10:00:00Z",
+    merchant: "Mercado Extra",
+    amount: 35.94,
+    category: "groceries",
+    description: "Mercado Extra R$ 35,94",
+    ...overrides,
+  };
+}
+
+describe("filterTransactions", () => {
+  const transactions: DecryptedTransaction[] = [
+    makeTx({
+      id: "tx-1",
+      card_id: "card-a",
+      timestamp_bucket: "2026-03",
+      merchant: "Mercado Extra",
+      amount: 35.94,
+      category: "groceries",
+    }),
+    makeTx({
+      id: "tx-2",
+      card_id: "card-b",
+      timestamp_bucket: "2026-03",
+      merchant: "Shell Posto",
+      amount: 250.0,
+      category: "transport",
+      description: "Shell Posto R$ 250,00",
+    }),
+    makeTx({
+      id: "tx-3",
+      card_id: "card-a",
+      timestamp_bucket: "2026-02",
+      merchant: "Padaria São João",
+      amount: 12.5,
+      category: "food",
+      description: "Padaria São João R$ 12,50",
+    }),
+    makeTx({
+      id: "tx-4",
+      card_id: "card-b",
+      timestamp_bucket: "2026-03",
+      merchant: "Netflix",
+      amount: 55.9,
+      category: "entertainment",
+      description: "Netflix R$ 55,90",
+    }),
+  ];
+
+  it("returns all transactions when no filters are active", () => {
+    const filters: TransactionFilters = {};
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters by month (timestamp_bucket)", () => {
+    const filters: TransactionFilters = { month: "2026-03" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(3);
+    expect(result.every((t) => t.timestamp_bucket === "2026-03")).toBe(true);
+  });
+
+  it("filters by card_id", () => {
+    const filters: TransactionFilters = { cardId: "card-a" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.card_id === "card-a")).toBe(true);
+  });
+
+  it("filters by category", () => {
+    const filters: TransactionFilters = { category: "groceries" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].merchant).toBe("Mercado Extra");
+  });
+
+  it("filters by minimum amount", () => {
+    const filters: TransactionFilters = { amountMin: 50 };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.amount >= 50)).toBe(true);
+  });
+
+  it("filters by maximum amount", () => {
+    const filters: TransactionFilters = { amountMax: 40 };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.amount <= 40)).toBe(true);
+  });
+
+  it("filters by amount range", () => {
+    const filters: TransactionFilters = { amountMin: 10, amountMax: 50 };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id).sort()).toEqual(["tx-1", "tx-3"]);
+  });
+
+  it("searches by merchant name (case-insensitive substring)", () => {
+    const filters: TransactionFilters = { search: "mercado" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].merchant).toBe("Mercado Extra");
+  });
+
+  it("searches by merchant name with partial match", () => {
+    const filters: TransactionFilters = { search: "shell" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].merchant).toBe("Shell Posto");
+  });
+
+  it("searches across description field too", () => {
+    const filters: TransactionFilters = { search: "R$ 35" };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("tx-1");
+  });
+
+  it("combines multiple filters (month + card + search)", () => {
+    const filters: TransactionFilters = {
+      month: "2026-03",
+      cardId: "card-b",
+      search: "shell",
+    };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].merchant).toBe("Shell Posto");
+  });
+
+  it("returns empty when no transactions match combined filters", () => {
+    const filters: TransactionFilters = {
+      month: "2026-03",
+      category: "food",
+    };
+    const result = filterTransactions(transactions, filters);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles empty transaction list", () => {
+    const result = filterTransactions([], { search: "anything" });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("parseFiltersFromParams", () => {
+  it("parses all filter params from URLSearchParams", () => {
+    const params = new URLSearchParams(
+      "month=2026-03&card=card-a&category=food&min=10&max=100&q=mercado"
+    );
+    const filters = parseFiltersFromParams(params);
+
+    expect(filters.month).toBe("2026-03");
+    expect(filters.cardId).toBe("card-a");
+    expect(filters.category).toBe("food");
+    expect(filters.amountMin).toBe(10);
+    expect(filters.amountMax).toBe(100);
+    expect(filters.search).toBe("mercado");
+  });
+
+  it("returns empty filters for empty params", () => {
+    const filters = parseFiltersFromParams(new URLSearchParams());
+    expect(filters).toEqual({});
+  });
+
+  it("ignores invalid numeric values", () => {
+    const params = new URLSearchParams("min=abc&max=xyz");
+    const filters = parseFiltersFromParams(params);
+    expect(filters.amountMin).toBeUndefined();
+    expect(filters.amountMax).toBeUndefined();
+  });
+});
+
+describe("filtersToParams", () => {
+  it("converts filters to URLSearchParams", () => {
+    const filters: TransactionFilters = {
+      month: "2026-03",
+      cardId: "card-a",
+      category: "food",
+      amountMin: 10,
+      amountMax: 100,
+      search: "mercado",
+    };
+    const params = filtersToParams(filters);
+
+    expect(params.get("month")).toBe("2026-03");
+    expect(params.get("card")).toBe("card-a");
+    expect(params.get("category")).toBe("food");
+    expect(params.get("min")).toBe("10");
+    expect(params.get("max")).toBe("100");
+    expect(params.get("q")).toBe("mercado");
+  });
+
+  it("omits undefined filter values", () => {
+    const filters: TransactionFilters = { month: "2026-03" };
+    const params = filtersToParams(filters);
+
+    expect(params.get("month")).toBe("2026-03");
+    expect(params.has("card")).toBe(false);
+    expect(params.has("q")).toBe(false);
+  });
+
+  it("returns empty params for empty filters", () => {
+    const params = filtersToParams({});
+    expect(params.toString()).toBe("");
+  });
+
+  it("roundtrips: filters → params → filters", () => {
+    const original: TransactionFilters = {
+      month: "2026-03",
+      cardId: "card-a",
+      search: "test",
+      amountMin: 5,
+      amountMax: 200,
+    };
+    const params = filtersToParams(original);
+    const restored = parseFiltersFromParams(params);
+    expect(restored).toEqual(original);
+  });
+});

--- a/dashboard/src/lib/filters.ts
+++ b/dashboard/src/lib/filters.ts
@@ -1,0 +1,129 @@
+/**
+ * Client-side filtering for decrypted transactions.
+ *
+ * All filtering operates on already-decrypted data in the browser.
+ * The server never sees filter criteria — maintaining zero-knowledge.
+ */
+
+import type { DecryptedTransaction } from "../types/dashboard";
+
+/** Active filter state for transactions. */
+export interface TransactionFilters {
+  month?: string;
+  cardId?: string;
+  category?: string;
+  amountMin?: number;
+  amountMax?: number;
+  search?: string;
+}
+
+/**
+ * Filters a list of decrypted transactions by the given criteria.
+ *
+ * All filters are combined with AND logic — a transaction must match
+ * every active filter to be included in the result.
+ */
+export function filterTransactions(
+  transactions: DecryptedTransaction[],
+  filters: TransactionFilters
+): DecryptedTransaction[] {
+  return transactions.filter((tx) => {
+    if (filters.month && tx.timestamp_bucket !== filters.month) {
+      return false;
+    }
+
+    if (filters.cardId && tx.card_id !== filters.cardId) {
+      return false;
+    }
+
+    if (filters.category && tx.category !== filters.category) {
+      return false;
+    }
+
+    if (filters.amountMin !== undefined && tx.amount < filters.amountMin) {
+      return false;
+    }
+
+    if (filters.amountMax !== undefined && tx.amount > filters.amountMax) {
+      return false;
+    }
+
+    if (filters.search) {
+      const query = filters.search.toLowerCase();
+      const matchesMerchant = tx.merchant.toLowerCase().includes(query);
+      const matchesDescription = tx.description.toLowerCase().includes(query);
+      if (!matchesMerchant && !matchesDescription) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/** URL param key mapping for filter state. */
+const PARAM_KEYS = {
+  month: "month",
+  cardId: "card",
+  category: "category",
+  amountMin: "min",
+  amountMax: "max",
+  search: "q",
+} as const;
+
+/**
+ * Parses filter state from URL search params.
+ *
+ * Enables shareable filter URLs like `/?month=2026-03&q=mercado`.
+ */
+export function parseFiltersFromParams(
+  params: URLSearchParams
+): TransactionFilters {
+  const filters: TransactionFilters = {};
+
+  const month = params.get(PARAM_KEYS.month);
+  if (month) filters.month = month;
+
+  const cardId = params.get(PARAM_KEYS.cardId);
+  if (cardId) filters.cardId = cardId;
+
+  const category = params.get(PARAM_KEYS.category);
+  if (category) filters.category = category;
+
+  const minStr = params.get(PARAM_KEYS.amountMin);
+  if (minStr) {
+    const min = Number(minStr);
+    if (!isNaN(min)) filters.amountMin = min;
+  }
+
+  const maxStr = params.get(PARAM_KEYS.amountMax);
+  if (maxStr) {
+    const max = Number(maxStr);
+    if (!isNaN(max)) filters.amountMax = max;
+  }
+
+  const search = params.get(PARAM_KEYS.search);
+  if (search) filters.search = search;
+
+  return filters;
+}
+
+/**
+ * Converts filter state to URL search params.
+ *
+ * Only includes params for active (non-undefined) filters.
+ */
+export function filtersToParams(filters: TransactionFilters): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.month) params.set(PARAM_KEYS.month, filters.month);
+  if (filters.cardId) params.set(PARAM_KEYS.cardId, filters.cardId);
+  if (filters.category) params.set(PARAM_KEYS.category, filters.category);
+  if (filters.amountMin !== undefined)
+    params.set(PARAM_KEYS.amountMin, String(filters.amountMin));
+  if (filters.amountMax !== undefined)
+    params.set(PARAM_KEYS.amountMax, String(filters.amountMax));
+  if (filters.search) params.set(PARAM_KEYS.search, filters.search);
+
+  return params;
+}

--- a/dashboard/src/pages/DashboardPage.tsx
+++ b/dashboard/src/pages/DashboardPage.tsx
@@ -1,17 +1,118 @@
+/**
+ * Main dashboard page showing decrypted transactions with filters.
+ *
+ * Fetches encrypted data from the API, decrypts client-side using
+ * the DEK, then applies filters on the decrypted plaintext.
+ */
+
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { listCards, listTransactions } from "../lib/api";
+import { decrypt } from "../lib/crypto";
+import { filterTransactions } from "../lib/filters";
 import { useAuth } from "../hooks/useAuth";
+import { useFilters } from "../hooks/useFilters";
+import { FilterBar } from "../components/FilterBar";
+import type { Transaction } from "../types/api";
+import type { DecryptedTransaction } from "../types/dashboard";
 
-/** Computes the current month bucket in YYYY-MM format. */
-function currentBucket(): string {
-  const now = new Date();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  return `${now.getFullYear()}-${month}`;
+/** Attempts to decrypt a transaction's encrypted_data and parse it. */
+async function decryptTransaction(
+  tx: Transaction,
+  dek: Uint8Array
+): Promise<DecryptedTransaction> {
+  try {
+    const plaintext = await decrypt(tx.encrypted_data, tx.iv, tx.auth_tag, dek);
+
+    // Try to parse as JSON first (structured data from iOS client)
+    try {
+      const parsed = JSON.parse(plaintext);
+      return {
+        id: tx.id,
+        card_id: tx.card_id,
+        timestamp_bucket: tx.timestamp_bucket,
+        created_at: tx.created_at,
+        merchant: parsed.merchant ?? parsed.name ?? plaintext,
+        amount: parsed.amount ?? 0,
+        category: parsed.category ?? "uncategorized",
+        description: plaintext,
+      };
+    } catch {
+      // Plaintext is not JSON — treat as simple description string
+      const amountMatch = plaintext.match(
+        /R\$\s*([\d.,]+)/
+      );
+      const amount = amountMatch
+        ? parseFloat(amountMatch[1].replace(".", "").replace(",", "."))
+        : 0;
+
+      return {
+        id: tx.id,
+        card_id: tx.card_id,
+        timestamp_bucket: tx.timestamp_bucket,
+        created_at: tx.created_at,
+        merchant: plaintext.replace(/R\$\s*[\d.,]+/, "").trim() || plaintext,
+        amount,
+        category: "uncategorized",
+        description: plaintext,
+      };
+    }
+  } catch {
+    // Decryption failed — show as encrypted
+    return {
+      id: tx.id,
+      card_id: tx.card_id,
+      timestamp_bucket: tx.timestamp_bucket,
+      created_at: tx.created_at,
+      merchant: "[Decryption failed]",
+      amount: 0,
+      category: "unknown",
+      description: "[Unable to decrypt]",
+    };
+  }
+}
+
+/** Hook that fetches and decrypts all transactions. */
+function useDecryptedTransactions() {
+  const { token, dek } = useAuth();
+
+  const transactionsQuery = useQuery({
+    queryKey: ["transactions"],
+    queryFn: () => listTransactions(token!),
+    enabled: !!token,
+  });
+
+  const decryptedQuery = useQuery({
+    queryKey: ["transactions:decrypted", transactionsQuery.data?.length],
+    queryFn: async () => {
+      if (!transactionsQuery.data || !dek) return [];
+      return Promise.all(
+        transactionsQuery.data.map((tx) => decryptTransaction(tx, dek))
+      );
+    },
+    enabled: !!transactionsQuery.data && !!dek,
+  });
+
+  return {
+    data: decryptedQuery.data ?? [],
+    isLoading: transactionsQuery.isLoading || decryptedQuery.isLoading,
+    isError: transactionsQuery.isError || decryptedQuery.isError,
+    error: transactionsQuery.error ?? decryptedQuery.error,
+  };
+}
+
+/** Formats a number as Brazilian Real currency. */
+function formatBRL(value: number): string {
+  return value.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
 }
 
 export function DashboardPage() {
   const { token } = useAuth();
-  const bucket = currentBucket();
+  const { filters, updateFilter, clearFilters, hasActiveFilters } =
+    useFilters();
 
   const cards = useQuery({
     queryKey: ["cards"],
@@ -19,23 +120,32 @@ export function DashboardPage() {
     enabled: !!token,
   });
 
-  const transactions = useQuery({
-    queryKey: ["transactions", bucket],
-    queryFn: () => listTransactions(token!, { timestamp_bucket: bucket }),
-    enabled: !!token,
-  });
+  const { data: allTransactions, isLoading, isError, error } =
+    useDecryptedTransactions();
+
+  const filtered = useMemo(
+    () => filterTransactions(allTransactions, filters),
+    [allTransactions, filters]
+  );
+
+  const totalAmount = useMemo(
+    () => filtered.reduce((sum, tx) => sum + tx.amount, 0),
+    [filtered]
+  );
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Viewing {bucket} &middot; All data is decrypted client-side
+          All data is decrypted client-side &middot;{" "}
+          {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
+          {hasActiveFilters ? " (filtered)" : ""}
         </p>
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
         <StatCard
           label="Cards"
           value={cards.data?.length ?? "..."}
@@ -43,41 +153,88 @@ export function DashboardPage() {
         />
         <StatCard
           label="Transactions"
-          value={transactions.data?.length ?? "..."}
-          loading={transactions.isLoading}
+          value={filtered.length}
+          loading={isLoading}
         />
-        <StatCard label="Period" value={bucket} loading={false} />
+        <StatCard
+          label="Total"
+          value={isLoading ? "..." : formatBRL(totalAmount)}
+          loading={false}
+        />
+        <StatCard
+          label="Avg"
+          value={
+            isLoading || filtered.length === 0
+              ? "..."
+              : formatBRL(totalAmount / filtered.length)
+          }
+          loading={false}
+        />
       </div>
 
-      {/* Transactions list (encrypted — placeholder) */}
+      {/* Filters */}
+      <FilterBar
+        filters={filters}
+        onFilterChange={updateFilter}
+        onClear={clearFilters}
+        hasActiveFilters={hasActiveFilters}
+        transactions={allTransactions}
+      />
+
+      {/* Transaction list */}
       <div className="rounded-lg border border-gray-200 bg-white">
         <div className="border-b border-gray-200 px-4 py-3">
           <h2 className="text-lg font-medium text-gray-900">
-            Transactions ({bucket})
+            Transactions
+            {hasActiveFilters && (
+              <span className="ml-2 text-sm font-normal text-gray-500">
+                ({filtered.length} of {allTransactions.length})
+              </span>
+            )}
           </h2>
         </div>
 
-        {transactions.isLoading ? (
-          <p className="p-4 text-sm text-gray-500">Loading...</p>
-        ) : transactions.data?.length === 0 ? (
+        {isLoading ? (
           <p className="p-4 text-sm text-gray-500">
-            No transactions this month.
+            Loading and decrypting...
           </p>
+        ) : filtered.length === 0 ? (
+          <div className="p-4 text-center">
+            <p className="text-sm text-gray-500">
+              {hasActiveFilters
+                ? "No transactions match your filters."
+                : "No transactions yet."}
+            </p>
+            {hasActiveFilters && (
+              <button
+                onClick={clearFilters}
+                className="mt-2 text-sm text-blue-600 hover:text-blue-800"
+              >
+                Clear all filters
+              </button>
+            )}
+          </div>
         ) : (
           <ul className="divide-y divide-gray-100">
-            {transactions.data?.map((tx) => (
-              <li key={tx.id} className="flex items-center justify-between px-4 py-3">
-                <div>
-                  <p className="text-sm font-medium text-gray-900">
-                    {tx.id.slice(0, 8)}...
+            {filtered.map((tx) => (
+              <li
+                key={tx.id}
+                className="flex items-center justify-between px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-gray-900">
+                    {tx.merchant}
                   </p>
                   <p className="text-xs text-gray-500">
-                    Card: {tx.card_id.slice(0, 8)}... &middot;{" "}
-                    {tx.timestamp_bucket}
+                    {tx.timestamp_bucket} &middot; {tx.category}
+                    {" · "}
+                    <span className="text-gray-400">
+                      {tx.card_id.slice(0, 8)}...
+                    </span>
                   </p>
                 </div>
-                <span className="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
-                  Encrypted
+                <span className="ml-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                  {formatBRL(tx.amount)}
                 </span>
               </li>
             ))}
@@ -85,9 +242,9 @@ export function DashboardPage() {
         )}
       </div>
 
-      {transactions.isError && (
+      {isError && (
         <p className="text-sm text-red-600">
-          Failed to load transactions: {transactions.error.message}
+          Failed to load transactions: {error?.message}
         </p>
       )}
     </div>

--- a/dashboard/src/types/dashboard.ts
+++ b/dashboard/src/types/dashboard.ts
@@ -1,0 +1,27 @@
+/**
+ * Client-side types for decrypted data and UI state.
+ *
+ * These types represent data after client-side decryption —
+ * they contain plaintext fields extracted from `encrypted_data`.
+ */
+
+/** A transaction after client-side decryption. */
+export interface DecryptedTransaction {
+  id: string;
+  card_id: string;
+  timestamp_bucket: string;
+  created_at: string;
+  merchant: string;
+  amount: number;
+  category: string;
+  description: string;
+}
+
+/** A card after client-side decryption. */
+export interface DecryptedCard {
+  id: string;
+  created_at: string;
+  label: string;
+  last_digits: string;
+  brand: string;
+}


### PR DESCRIPTION
## Summary
- Add transaction filtering and search that operates entirely on **decrypted data** client-side — the server never sees filter criteria (zero-knowledge)
- Filter by: **month**, **card**, **category**, **amount range** (min/max)
- **Search by merchant name** with case-insensitive substring matching across merchant and description fields
- Filters sync with **URL query params** (e.g. `/?month=2026-03&q=mercado`) for shareable/bookmarkable states
- **Clear all filters** button when any filter is active
- Stats cards (Total, Average, Count) **update in real-time** as filters change
- Transactions are decrypted and displayed with merchant name and amount in BRL format

## New files
- `lib/filters.ts` — `filterTransactions()`, `parseFiltersFromParams()`, `filtersToParams()`
- `lib/filters.test.ts` — 20 unit tests for all filter combinations
- `types/dashboard.ts` — `DecryptedTransaction` and `DecryptedCard` types
- `hooks/useFilters.ts` — URL-synced filter state hook via `useSearchParams`
- `components/FilterBar.tsx` — filter UI with search input, dropdowns, amount range

## Test plan
- [x] 20 unit tests for filter logic (month, card, category, amount range, search, combined, empty)
- [x] URL params roundtrip: filters → params → filters
- [x] Invalid numeric params ignored gracefully
- [x] All 51 tests passing (20 filters + 14 session + 17 crypto)
- [x] ESLint clean
- [x] TypeScript compilation clean
- [x] Production build succeeds

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)