### PR TITLE
feat(dashboard): transaction list with decryption and month pagination

### DIFF
--- a/dashboard/src/lib/transactions.test.ts
+++ b/dashboard/src/lib/transactions.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  sortByDateDescending,
+  formatTransactionDate,
+  getMonthBuckets,
+  navigateMonth,
+  currentBucket,
+} from "./transactions";
+import type { DecryptedTransaction } from "../types/dashboard";
+
+function makeTx(
+  overrides: Partial<DecryptedTransaction> = {}
+): DecryptedTransaction {
+  return {
+    id: "tx-1",
+    card_id: "card-1",
+    timestamp_bucket: "2026-03",
+    created_at: "2026-03-15T10:00:00Z",
+    merchant: "Test Merchant",
+    amount: 10,
+    category: "test",
+    description: "Test",
+    ...overrides,
+  };
+}
+
+describe("sortByDateDescending", () => {
+  it("sorts transactions by created_at descending (newest first)", () => {
+    const transactions = [
+      makeTx({ id: "old", created_at: "2026-03-01T08:00:00Z" }),
+      makeTx({ id: "newest", created_at: "2026-03-25T18:00:00Z" }),
+      makeTx({ id: "mid", created_at: "2026-03-15T12:00:00Z" }),
+    ];
+
+    const sorted = sortByDateDescending(transactions);
+
+    expect(sorted.map((t) => t.id)).toEqual(["newest", "mid", "old"]);
+  });
+
+  it("does not mutate the original array", () => {
+    const original = [
+      makeTx({ id: "a", created_at: "2026-03-01T00:00:00Z" }),
+      makeTx({ id: "b", created_at: "2026-03-02T00:00:00Z" }),
+    ];
+    const copy = [...original];
+
+    sortByDateDescending(original);
+
+    expect(original.map((t) => t.id)).toEqual(copy.map((t) => t.id));
+  });
+
+  it("handles empty array", () => {
+    expect(sortByDateDescending([])).toEqual([]);
+  });
+
+  it("handles single transaction", () => {
+    const single = [makeTx({ id: "only" })];
+    expect(sortByDateDescending(single)).toHaveLength(1);
+  });
+});
+
+describe("formatTransactionDate", () => {
+  it("formats ISO date to readable format", () => {
+    const result = formatTransactionDate("2026-03-15T10:30:00Z");
+    // Should contain day, month info
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("formats different dates consistently", () => {
+    const a = formatTransactionDate("2026-03-15T10:00:00Z");
+    const b = formatTransactionDate("2026-03-15T10:00:00Z");
+    expect(a).toBe(b);
+  });
+
+  it("produces different results for different dates", () => {
+    const a = formatTransactionDate("2026-03-15T10:00:00Z");
+    const b = formatTransactionDate("2026-04-20T10:00:00Z");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("getMonthBuckets", () => {
+  it("extracts unique sorted months from transactions", () => {
+    const transactions = [
+      makeTx({ timestamp_bucket: "2026-03" }),
+      makeTx({ timestamp_bucket: "2026-01" }),
+      makeTx({ timestamp_bucket: "2026-03" }),
+      makeTx({ timestamp_bucket: "2026-02" }),
+    ];
+
+    const buckets = getMonthBuckets(transactions);
+
+    expect(buckets).toEqual(["2026-01", "2026-02", "2026-03"]);
+  });
+
+  it("returns empty array for no transactions", () => {
+    expect(getMonthBuckets([])).toEqual([]);
+  });
+});
+
+describe("navigateMonth", () => {
+  it("goes to next month", () => {
+    expect(navigateMonth("2026-03", 1)).toBe("2026-04");
+  });
+
+  it("goes to previous month", () => {
+    expect(navigateMonth("2026-03", -1)).toBe("2026-02");
+  });
+
+  it("handles year boundary forward (Dec → Jan)", () => {
+    expect(navigateMonth("2026-12", 1)).toBe("2027-01");
+  });
+
+  it("handles year boundary backward (Jan → Dec)", () => {
+    expect(navigateMonth("2026-01", -1)).toBe("2025-12");
+  });
+
+  it("pads month with zero", () => {
+    expect(navigateMonth("2026-09", 1)).toBe("2026-10");
+    expect(navigateMonth("2026-10", -1)).toBe("2026-09");
+  });
+});
+
+describe("currentBucket", () => {
+  it("returns a string in YYYY-MM format", () => {
+    const bucket = currentBucket();
+    expect(bucket).toMatch(/^\d{4}-\d{2}$/);
+  });
+});

--- a/dashboard/src/lib/transactions.ts
+++ b/dashboard/src/lib/transactions.ts
@@ -1,0 +1,89 @@
+/**
+ * Transaction utilities for sorting, formatting, and month navigation.
+ *
+ * These functions operate on decrypted transaction data and handle
+ * the display logic for the transaction list view.
+ */
+
+import type { DecryptedTransaction } from "../types/dashboard";
+
+/**
+ * Returns a new array of transactions sorted by created_at descending.
+ *
+ * Does not mutate the original array.
+ */
+export function sortByDateDescending(
+  transactions: DecryptedTransaction[]
+): DecryptedTransaction[] {
+  return [...transactions].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+}
+
+/**
+ * Formats an ISO date string into a human-readable date.
+ *
+ * Uses pt-BR locale for Brazilian date formatting (DD/MM/YYYY HH:MM).
+ */
+export function formatTransactionDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Extracts unique month buckets from transactions, sorted chronologically.
+ */
+export function getMonthBuckets(
+  transactions: DecryptedTransaction[]
+): string[] {
+  const buckets = new Set(transactions.map((t) => t.timestamp_bucket));
+  return Array.from(buckets).sort();
+}
+
+/**
+ * Navigates to a different month bucket by offset.
+ *
+ * @param bucket - Current month in "YYYY-MM" format
+ * @param offset - Number of months to move (+1 = next, -1 = previous)
+ * @returns The new month bucket in "YYYY-MM" format
+ */
+export function navigateMonth(bucket: string, offset: number): string {
+  const [yearStr, monthStr] = bucket.split("-");
+  let year = parseInt(yearStr, 10);
+  let month = parseInt(monthStr, 10) + offset;
+
+  while (month > 12) {
+    month -= 12;
+    year++;
+  }
+  while (month < 1) {
+    month += 12;
+    year--;
+  }
+
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+/** Returns the current month bucket in "YYYY-MM" format. */
+export function currentBucket(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  return `${now.getFullYear()}-${month}`;
+}
+
+/**
+ * Formats a month bucket ("YYYY-MM") into a human-readable label.
+ *
+ * Example: "2026-03" → "Mar 2026"
+ */
+export function formatBucket(bucket: string): string {
+  const [year, month] = bucket.split("-");
+  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1);
+  return date.toLocaleDateString("pt-BR", { month: "short", year: "numeric" });
+}

--- a/dashboard/src/pages/DashboardPage.tsx
+++ b/dashboard/src/pages/DashboardPage.tsx
@@ -2,14 +2,22 @@
  * Main dashboard page showing decrypted transactions with filters.
  *
  * Fetches encrypted data from the API, decrypts client-side using
- * the DEK, then applies filters on the decrypted plaintext.
+ * the DEK, sorts by date descending, and applies client-side filters.
+ * Defaults to the current month with prev/next month navigation.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { listCards, listTransactions } from "../lib/api";
 import { decrypt } from "../lib/crypto";
 import { filterTransactions } from "../lib/filters";
+import {
+  sortByDateDescending,
+  formatTransactionDate,
+  navigateMonth,
+  currentBucket,
+  formatBucket,
+} from "../lib/transactions";
 import { useAuth } from "../hooks/useAuth";
 import { useFilters } from "../hooks/useFilters";
 import { FilterBar } from "../components/FilterBar";
@@ -39,9 +47,7 @@ async function decryptTransaction(
       };
     } catch {
       // Plaintext is not JSON — treat as simple description string
-      const amountMatch = plaintext.match(
-        /R\$\s*([\d.,]+)/
-      );
+      const amountMatch = plaintext.match(/R\$\s*([\d.,]+)/);
       const amount = amountMatch
         ? parseFloat(amountMatch[1].replace(".", "").replace(",", "."))
         : 0;
@@ -58,7 +64,6 @@ async function decryptTransaction(
       };
     }
   } catch {
-    // Decryption failed — show as encrypted
     return {
       id: tx.id,
       card_id: tx.card_id,
@@ -114,6 +119,16 @@ export function DashboardPage() {
   const { filters, updateFilter, clearFilters, hasActiveFilters } =
     useFilters();
 
+  // Default to current month if no month filter is set
+  const defaultBucket = currentBucket();
+  useEffect(() => {
+    if (!filters.month) {
+      updateFilter("month", defaultBucket);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const activeMonth = filters.month ?? defaultBucket;
+
   const cards = useQuery({
     queryKey: ["cards"],
     queryFn: () => listCards(token!),
@@ -123,25 +138,70 @@ export function DashboardPage() {
   const { data: allTransactions, isLoading, isError, error } =
     useDecryptedTransactions();
 
-  const filtered = useMemo(
-    () => filterTransactions(allTransactions, filters),
-    [allTransactions, filters]
-  );
+  // Apply filters then sort by date descending
+  const filtered = useMemo(() => {
+    const matched = filterTransactions(allTransactions, filters);
+    return sortByDateDescending(matched);
+  }, [allTransactions, filters]);
 
   const totalAmount = useMemo(
     () => filtered.reduce((sum, tx) => sum + tx.amount, 0),
     [filtered]
   );
 
+  function goToPreviousMonth() {
+    updateFilter("month", navigateMonth(activeMonth, -1));
+  }
+
+  function goToNextMonth() {
+    updateFilter("month", navigateMonth(activeMonth, 1));
+  }
+
+  function goToCurrentMonth() {
+    updateFilter("month", defaultBucket);
+  }
+
+  const isCurrentMonth = activeMonth === defaultBucket;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          All data is decrypted client-side &middot;{" "}
-          {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
-          {hasActiveFilters ? " (filtered)" : ""}
-        </p>
+      {/* Header with month navigation */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            All data is decrypted client-side &middot;{" "}
+            {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+
+        {/* Month pagination */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={goToPreviousMonth}
+            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50"
+            aria-label="Previous month"
+          >
+            &larr;
+          </button>
+          <button
+            onClick={goToCurrentMonth}
+            className={`rounded-md px-3 py-1 text-sm font-medium ${
+              isCurrentMonth
+                ? "bg-blue-600 text-white"
+                : "border border-gray-300 text-gray-700 hover:bg-gray-50"
+            }`}
+          >
+            {formatBucket(activeMonth)}
+          </button>
+          <button
+            onClick={goToNextMonth}
+            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50"
+            aria-label="Next month"
+          >
+            &rarr;
+          </button>
+        </div>
       </div>
 
       {/* Stats */}
@@ -226,7 +286,9 @@ export function DashboardPage() {
                     {tx.merchant}
                   </p>
                   <p className="text-xs text-gray-500">
-                    {tx.timestamp_bucket} &middot; {tx.category}
+                    {formatTransactionDate(tx.created_at)}
+                    {" · "}
+                    {tx.category}
                     {" · "}
                     <span className="text-gray-400">
                       {tx.card_id.slice(0, 8)}...


### PR DESCRIPTION
## Summary
- Transactions **sorted by date descending** (newest first)
- **Default filter to current month** on page load
- **Month pagination** with prev/next arrows and a "today" button showing the formatted month label
- **Human-readable date display** in pt-BR format (DD/MM/YYYY HH:MM)
- Each transaction displays: **date, merchant, amount (R$), card, category**
- Loading state shown while fetching and decrypting

## Acceptance Criteria
- [x] Fetches transactions from API (filtered by current month by default)
- [x] Decrypts each transaction encrypted_data client-side
- [x] Displays: date, merchant, amount, card, category
- [x] Sorted by date descending
- [x] Loading state while fetching/decrypting
- [x] Pagination by month (timestamp_bucket filter)

## Test plan
- [x] 15 unit tests for transaction utilities (sorting, date formatting, month navigation, year boundaries)
- [x] All 66 tests passing (15 transactions + 20 filters + 14 session + 17 crypto)
- [x] ESLint clean
- [x] TypeScript compilation clean
- [x] Production build succeeds

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)