### PR TITLE
feat(dashboard): implement card management UI

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Layout } from "./components/Layout";
 import { LoginPage } from "./pages/LoginPage";
 import { DashboardPage } from "./pages/DashboardPage";
+import { CardsPage } from "./pages/CardsPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { useAuth } from "./hooks/useAuth";
 import { useTokenRefresh } from "./hooks/useTokenRefresh";
@@ -48,6 +49,14 @@ export default function App() {
                 element={
                   <ProtectedRoute>
                     <DashboardPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/cards"
+                element={
+                  <ProtectedRoute>
+                    <CardsPage />
                   </ProtectedRoute>
                 }
               />

--- a/dashboard/src/components/FilterBar.tsx
+++ b/dashboard/src/components/FilterBar.tsx
@@ -17,6 +17,8 @@ interface FilterBarProps {
   onClear: () => void;
   hasActiveFilters: boolean;
   transactions: DecryptedTransaction[];
+  /** Map of card_id → display label for the card selector. */
+  cardLabels?: Map<string, string>;
 }
 
 /** Extracts unique sorted values from a field across transactions. */
@@ -34,6 +36,7 @@ export function FilterBar({
   onClear,
   hasActiveFilters,
   transactions,
+  cardLabels,
 }: FilterBarProps) {
   const months = uniqueValues(transactions, "timestamp_bucket");
   const categories = uniqueValues(transactions, "category");
@@ -102,7 +105,7 @@ export function FilterBar({
             <option value="">All cards</option>
             {cardIds.map((c) => (
               <option key={c} value={c}>
-                {c.slice(0, 8)}...
+                {cardLabels?.get(c) ?? `${c.slice(0, 8)}...`}
               </option>
             ))}
           </select>

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -20,6 +20,12 @@ export function Layout() {
               >
                 Dashboard
               </Link>
+              <Link
+                to="/cards"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
+                Cards
+              </Link>
               <button
                 onClick={logout}
                 className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"

--- a/dashboard/src/lib/api.test.ts
+++ b/dashboard/src/lib/api.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createCard, deleteCard, ApiClientError } from "./api";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createCard", () => {
+  it("sends POST with encrypted card data and returns the card", async () => {
+    const card = {
+      id: "card-new",
+      user_id: "user-1",
+      encrypted_data: "enc",
+      iv: "iv",
+      auth_tag: "tag",
+      created_at: "2026-03-15T10:00:00Z",
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: card }),
+    });
+
+    const result = await createCard("test-token", {
+      encrypted_data: "enc",
+      iv: "iv",
+      auth_tag: "tag",
+    });
+
+    expect(result).toEqual(card);
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/cards");
+    expect(options.method).toBe("POST");
+    expect(options.headers["Authorization"]).toBe("Bearer test-token");
+    expect(JSON.parse(options.body)).toEqual({
+      encrypted_data: "enc",
+      iv: "iv",
+      auth_tag: "tag",
+    });
+  });
+
+  it("throws ApiClientError on failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: async () => ({
+        error: { code: "VALIDATION_ERROR", message: "Invalid payload" },
+      }),
+    });
+
+    await expect(
+      createCard("test-token", {
+        encrypted_data: "enc",
+        iv: "iv",
+        auth_tag: "tag",
+      })
+    ).rejects.toThrow(ApiClientError);
+  });
+});
+
+describe("deleteCard", () => {
+  it("sends DELETE request and resolves on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: null }),
+    });
+
+    await deleteCard("test-token", "card-123");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/cards/card-123");
+    expect(options.method).toBe("DELETE");
+    expect(options.headers["Authorization"]).toBe("Bearer test-token");
+  });
+
+  it("throws ApiClientError on failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: async () => ({
+        error: { code: "NOT_FOUND", message: "Card not found" },
+      }),
+    });
+
+    await expect(deleteCard("test-token", "card-123")).rejects.toThrow(
+      ApiClientError
+    );
+  });
+});

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse, Card, LoginRequest, LoginResponse, Transaction } from "../types/api";
+import type { ApiResponse, Card, CreateCardRequest, LoginRequest, LoginResponse, Transaction } from "../types/api";
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? "";
 
@@ -57,6 +57,31 @@ export async function refreshToken(token: string): Promise<{ token: string }> {
 
 export async function listCards(token: string): Promise<Card[]> {
   return apiFetch<Card[]>("/v1/cards", { headers: headers(token) });
+}
+
+export async function createCard(
+  token: string,
+  payload: CreateCardRequest,
+): Promise<Card> {
+  return apiFetch<Card>("/v1/cards", {
+    method: "POST",
+    headers: headers(token),
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteCard(token: string, id: string): Promise<void> {
+  const res = await fetch(`${BASE_URL}/v1/cards/${id}`, {
+    method: "DELETE",
+    headers: headers(token),
+  });
+
+  if (!res.ok) {
+    const body = await res.json();
+    const msg = body?.error?.message ?? res.statusText;
+    const code = body?.error?.code ?? "UNKNOWN";
+    throw new ApiClientError(msg, code, res.status);
+  }
 }
 
 // ── Transactions ────────────────────────────────────────────────────────────

--- a/dashboard/src/lib/card-data.test.ts
+++ b/dashboard/src/lib/card-data.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { decryptCard, encryptCardData, formatCardLabel } from "./card-data";
+import { encrypt, decrypt, base64ToBytes } from "./crypto";
+
+function makeEncrypted(dek: Uint8Array) {
+  return async (plaintext: string) => {
+    const result = await encrypt(plaintext, dek);
+    return {
+      id: "card-1",
+      user_id: "user-1",
+      encrypted_data: result.encrypted_data,
+      iv: result.iv,
+      auth_tag: result.auth_tag,
+      created_at: "2026-03-15T10:00:00Z",
+    };
+  };
+}
+
+describe("decryptCard", () => {
+  it("decrypts a card with JSON encrypted_data", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const make = makeEncrypted(dek);
+    const card = await make(
+      JSON.stringify({ label: "Nubank Platinum", last_digits: "4567", brand: "Mastercard" })
+    );
+
+    const result = await decryptCard(card, dek);
+
+    expect(result.id).toBe("card-1");
+    expect(result.label).toBe("Nubank Platinum");
+    expect(result.last_digits).toBe("4567");
+    expect(result.brand).toBe("Mastercard");
+    expect(result.created_at).toBe("2026-03-15T10:00:00Z");
+  });
+
+  it("handles plaintext (non-JSON) encrypted_data", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const make = makeEncrypted(dek);
+    const card = await make("Nubank ...4567");
+
+    const result = await decryptCard(card, dek);
+
+    expect(result.label).toBe("Nubank ...4567");
+    expect(result.last_digits).toBe("");
+    expect(result.brand).toBe("");
+  });
+
+  it("returns placeholder on decryption failure", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const wrongDek = crypto.getRandomValues(new Uint8Array(32));
+    const make = makeEncrypted(dek);
+    const card = await make("secret card data");
+
+    const result = await decryptCard(card, wrongDek);
+
+    expect(result.label).toBe("[Decryption failed]");
+  });
+});
+
+describe("encryptCardData", () => {
+  it("encrypts card data as JSON and returns encrypted fields", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+
+    const result = await encryptCardData(
+      { label: "Bradesco Visa", last_digits: "1234", brand: "Visa" },
+      dek
+    );
+
+    expect(result.encrypted_data).toBeTruthy();
+    expect(result.iv).toBeTruthy();
+    expect(result.auth_tag).toBeTruthy();
+
+    // Verify it can be decrypted back
+    const decrypted = await decrypt(result.encrypted_data, result.iv, result.auth_tag, dek);
+    const parsed = JSON.parse(decrypted);
+    expect(parsed.label).toBe("Bradesco Visa");
+    expect(parsed.last_digits).toBe("1234");
+    expect(parsed.brand).toBe("Visa");
+  });
+
+  it("produces valid base64 with correct lengths", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+
+    const result = await encryptCardData(
+      { label: "Test", last_digits: "0000", brand: "Test" },
+      dek
+    );
+
+    expect(base64ToBytes(result.iv).length).toBe(12);
+    expect(base64ToBytes(result.auth_tag).length).toBe(16);
+  });
+});
+
+describe("formatCardLabel", () => {
+  it("formats card with label and last digits", () => {
+    expect(formatCardLabel("Nubank", "4567")).toBe("Nubank ••4567");
+  });
+
+  it("formats card with label only when no last digits", () => {
+    expect(formatCardLabel("My Card", "")).toBe("My Card");
+  });
+
+  it("formats card with last digits only when no label", () => {
+    expect(formatCardLabel("", "1234")).toBe("••1234");
+  });
+
+  it("returns fallback when both are empty", () => {
+    expect(formatCardLabel("", "")).toBe("Unknown card");
+  });
+});

--- a/dashboard/src/lib/card-data.ts
+++ b/dashboard/src/lib/card-data.ts
@@ -1,0 +1,101 @@
+/**
+ * Card data utilities for client-side encryption and decryption.
+ *
+ * Handles converting between encrypted API card data and
+ * the plaintext DecryptedCard type used in the UI.
+ */
+
+import { decrypt, encrypt } from "./crypto";
+import type { Card } from "../types/api";
+import type { DecryptedCard } from "../types/dashboard";
+import type { EncryptResult } from "./crypto";
+
+/** Input data for creating an encrypted card. */
+export interface CardFormData {
+  label: string;
+  last_digits: string;
+  brand: string;
+}
+
+/**
+ * Decrypts a single card's encrypted_data and extracts structured fields.
+ *
+ * Tries to parse the decrypted plaintext as JSON first. If it's not JSON,
+ * uses the raw plaintext as the label with empty last_digits and brand.
+ *
+ * @param card - Encrypted card from the API
+ * @param dek - Raw DEK as Uint8Array (32 bytes)
+ * @returns Decrypted card with label, last_digits, and brand
+ */
+export async function decryptCard(
+  card: Card,
+  dek: Uint8Array
+): Promise<DecryptedCard> {
+  try {
+    const plaintext = await decrypt(card.encrypted_data, card.iv, card.auth_tag, dek);
+
+    try {
+      const parsed = JSON.parse(plaintext);
+      return {
+        id: card.id,
+        created_at: card.created_at,
+        label: parsed.label ?? plaintext,
+        last_digits: parsed.last_digits ?? "",
+        brand: parsed.brand ?? "",
+      };
+    } catch {
+      // Not JSON — use raw plaintext as label
+      return {
+        id: card.id,
+        created_at: card.created_at,
+        label: plaintext,
+        last_digits: "",
+        brand: "",
+      };
+    }
+  } catch {
+    return {
+      id: card.id,
+      created_at: card.created_at,
+      label: "[Decryption failed]",
+      last_digits: "",
+      brand: "",
+    };
+  }
+}
+
+/**
+ * Encrypts card form data into the format expected by the API.
+ *
+ * Serializes the card data as JSON and encrypts it with AES-256-GCM.
+ *
+ * @param data - Card form data (label, last_digits, brand)
+ * @param dek - Raw DEK as Uint8Array (32 bytes)
+ * @returns Encrypted fields ready for the API (encrypted_data, iv, auth_tag)
+ */
+export async function encryptCardData(
+  data: CardFormData,
+  dek: Uint8Array
+): Promise<EncryptResult> {
+  const plaintext = JSON.stringify({
+    label: data.label,
+    last_digits: data.last_digits,
+    brand: data.brand,
+  });
+
+  return encrypt(plaintext, dek);
+}
+
+/**
+ * Formats a card label for display, combining label and last digits.
+ *
+ * @example
+ * formatCardLabel("Nubank", "4567") // "Nubank ••4567"
+ * formatCardLabel("My Card", "")    // "My Card"
+ */
+export function formatCardLabel(label: string, lastDigits: string): string {
+  if (label && lastDigits) return `${label} ••${lastDigits}`;
+  if (label) return label;
+  if (lastDigits) return `••${lastDigits}`;
+  return "Unknown card";
+}

--- a/dashboard/src/lib/crypto.test.ts
+++ b/dashboard/src/lib/crypto.test.ts
@@ -3,6 +3,7 @@ import {
   deriveKey,
   unwrapDek,
   decrypt,
+  encrypt,
   base64ToBytes,
   bytesToBase64,
 } from "./crypto";
@@ -517,6 +518,55 @@ describe("end-to-end: wrap → unwrap → encrypt → decrypt", () => {
 
     // 7. Decrypt the data
     const decrypted = await decrypt(ciphertextB64, encIvB64, authTagB64, unwrappedDek);
+
+    expect(decrypted).toBe(plaintext);
+  });
+});
+
+describe("encrypt", () => {
+  it("encrypts plaintext and returns base64 ciphertext, iv, and auth_tag", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const plaintext = "Nubank Mastercard ...4567";
+
+    const result = await encrypt(plaintext, dek);
+
+    expect(result.encrypted_data).toBeTruthy();
+    expect(result.iv).toBeTruthy();
+    expect(result.auth_tag).toBeTruthy();
+
+    // IV should be 12 bytes = 16 base64 chars
+    expect(base64ToBytes(result.iv).length).toBe(12);
+    // Auth tag should be 16 bytes
+    expect(base64ToBytes(result.auth_tag).length).toBe(16);
+  });
+
+  it("produces output that can be decrypted", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const plaintext = "Bradesco Visa ...1234 — Padaria R$ 8,50";
+
+    const { encrypted_data, iv, auth_tag } = await encrypt(plaintext, dek);
+    const decrypted = await decrypt(encrypted_data, iv, auth_tag, dek);
+
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("produces different ciphertexts for same plaintext (random IV)", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const plaintext = "Same content";
+
+    const result1 = await encrypt(plaintext, dek);
+    const result2 = await encrypt(plaintext, dek);
+
+    expect(result1.iv).not.toBe(result2.iv);
+    expect(result1.encrypted_data).not.toBe(result2.encrypted_data);
+  });
+
+  it("handles UTF-8 content with special characters", async () => {
+    const dek = crypto.getRandomValues(new Uint8Array(32));
+    const plaintext = '{"label":"Cartão São Paulo","last_digits":"9876","brand":"Visa"}';
+
+    const { encrypted_data, iv, auth_tag } = await encrypt(plaintext, dek);
+    const decrypted = await decrypt(encrypted_data, iv, auth_tag, dek);
 
     expect(decrypted).toBe(plaintext);
   });

--- a/dashboard/src/lib/crypto.ts
+++ b/dashboard/src/lib/crypto.ts
@@ -18,6 +18,9 @@ const IV_LENGTH = 12;
 /** AES-GCM authentication tag length in bits. */
 const TAG_LENGTH_BITS = 128;
 
+/** AES-GCM authentication tag length in bytes. */
+const TAG_LENGTH_BYTES = 16;
+
 
 /** Parameters for DEK derivation via PBKDF2. */
 export interface DekParams {
@@ -199,5 +202,60 @@ export async function decrypt(
     throw new CryptoError(
       "Decryption failed: wrong key or tampered data"
     );
+  }
+}
+
+/** Result of encrypting plaintext with AES-256-GCM. */
+export interface EncryptResult {
+  encrypted_data: string;
+  iv: string;
+  auth_tag: string;
+}
+
+/**
+ * Encrypts a plaintext string using AES-256-GCM with the DEK.
+ *
+ * Generates a random 12-byte IV for each encryption. The output is split
+ * into separate ciphertext and auth tag fields to match the CardPulse API
+ * format expected by the server.
+ *
+ * @param plaintext - The UTF-8 string to encrypt
+ * @param dek - Raw DEK as Uint8Array (32 bytes)
+ * @returns Base64-encoded encrypted_data, iv, and auth_tag
+ *
+ * @throws {CryptoError} If encryption fails
+ */
+export async function encrypt(
+  plaintext: string,
+  dek: Uint8Array
+): Promise<EncryptResult> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    dek.buffer as ArrayBuffer,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"]
+  );
+
+  try {
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv.buffer as ArrayBuffer, tagLength: TAG_LENGTH_BITS },
+      key,
+      new TextEncoder().encode(plaintext)
+    );
+
+    const encBytes = new Uint8Array(encrypted);
+    const ciphertext = encBytes.slice(0, encBytes.length - TAG_LENGTH_BYTES);
+    const authTag = encBytes.slice(encBytes.length - TAG_LENGTH_BYTES);
+
+    return {
+      encrypted_data: bytesToBase64(ciphertext),
+      iv: bytesToBase64(iv),
+      auth_tag: bytesToBase64(authTag),
+    };
+  } catch {
+    throw new CryptoError("Encryption failed");
   }
 }

--- a/dashboard/src/pages/CardsPage.tsx
+++ b/dashboard/src/pages/CardsPage.tsx
@@ -1,0 +1,285 @@
+/**
+ * Card management page for viewing, adding, and deleting credit cards.
+ *
+ * All card data is encrypted client-side before being sent to the API
+ * and decrypted client-side after fetching. The server never sees plaintext.
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listCards, createCard, deleteCard } from "../lib/api";
+import { decryptCard, encryptCardData, formatCardLabel } from "../lib/card-data";
+import { useAuth } from "../hooks/useAuth";
+
+/** Hook that fetches and decrypts all cards. */
+function useDecryptedCards() {
+  const { token, dek } = useAuth();
+
+  const cardsQuery = useQuery({
+    queryKey: ["cards"],
+    queryFn: () => listCards(token!),
+    enabled: !!token,
+  });
+
+  const decryptedQuery = useQuery({
+    queryKey: ["cards:decrypted", cardsQuery.data?.length],
+    queryFn: async () => {
+      if (!cardsQuery.data || !dek) return [];
+      return Promise.all(
+        cardsQuery.data.map((card) => decryptCard(card, dek)),
+      );
+    },
+    enabled: !!cardsQuery.data && !!dek,
+  });
+
+  return {
+    data: decryptedQuery.data ?? [],
+    isLoading: cardsQuery.isLoading || decryptedQuery.isLoading,
+    isError: cardsQuery.isError || decryptedQuery.isError,
+    error: cardsQuery.error ?? decryptedQuery.error,
+  };
+}
+
+export function CardsPage() {
+  const { token, dek } = useAuth();
+  const queryClient = useQueryClient();
+  const { data: cards, isLoading, isError, error } = useDecryptedCards();
+
+  const [showForm, setShowForm] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  // ── Add card mutation ──
+  const addMutation = useMutation({
+    mutationFn: async (formData: {
+      label: string;
+      last_digits: string;
+      brand: string;
+    }) => {
+      const encrypted = await encryptCardData(formData, dek!);
+      return createCard(token!, encrypted);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      setShowForm(false);
+    },
+  });
+
+  // ── Delete card mutation ──
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCard(token!, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      setDeleteConfirmId(null);
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Cards</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Manage your tracked credit cards &middot;{" "}
+            {cards.length} card{cards.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <button
+          onClick={() => setShowForm(true)}
+          disabled={showForm}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Add card
+        </button>
+      </div>
+
+      {/* Add card form */}
+      {showForm && (
+        <AddCardForm
+          onSubmit={(data) => addMutation.mutate(data)}
+          onCancel={() => setShowForm(false)}
+          isSubmitting={addMutation.isPending}
+          error={addMutation.error?.message}
+        />
+      )}
+
+      {/* Card list */}
+      <div className="rounded-lg border border-gray-200 bg-white">
+        <div className="border-b border-gray-200 px-4 py-3">
+          <h2 className="text-lg font-medium text-gray-900">Your cards</h2>
+        </div>
+
+        {isLoading ? (
+          <p className="p-4 text-sm text-gray-500">
+            Loading and decrypting...
+          </p>
+        ) : cards.length === 0 ? (
+          <p className="p-4 text-center text-sm text-gray-500">
+            No cards yet. Add your first card to get started.
+          </p>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {cards.map((card) => (
+              <li
+                key={card.id}
+                className="flex items-center justify-between px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900">
+                    {formatCardLabel(card.label, card.last_digits)}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {card.brand || "No brand"}
+                    {" · "}
+                    Added {new Date(card.created_at).toLocaleDateString("pt-BR")}
+                  </p>
+                </div>
+
+                {deleteConfirmId === card.id ? (
+                  <div className="ml-4 flex items-center gap-2">
+                    <span className="text-xs text-red-600">Delete?</span>
+                    <button
+                      onClick={() => deleteMutation.mutate(card.id)}
+                      disabled={deleteMutation.isPending}
+                      className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700 disabled:opacity-50"
+                    >
+                      {deleteMutation.isPending ? "..." : "Yes"}
+                    </button>
+                    <button
+                      onClick={() => setDeleteConfirmId(null)}
+                      className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200"
+                    >
+                      No
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setDeleteConfirmId(card.id)}
+                    className="ml-4 rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                  >
+                    Delete
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {isError && (
+        <p className="text-sm text-red-600">
+          Failed to load cards: {error?.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Form for adding a new card with client-side encryption. */
+function AddCardForm({
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  error,
+}: {
+  onSubmit: (data: { label: string; last_digits: string; brand: string }) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+  error?: string;
+}) {
+  const [label, setLabel] = useState("");
+  const [lastDigits, setLastDigits] = useState("");
+  const [brand, setBrand] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!label.trim()) return;
+    onSubmit({
+      label: label.trim(),
+      last_digits: lastDigits.trim(),
+      brand: brand.trim(),
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3"
+    >
+      <h3 className="text-sm font-medium text-gray-900">Add new card</h3>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div>
+          <label htmlFor="card-label" className="block text-xs text-gray-600">
+            Card name *
+          </label>
+          <input
+            id="card-label"
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="e.g. Nubank Platinum"
+            required
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="card-digits" className="block text-xs text-gray-600">
+            Last 4 digits
+          </label>
+          <input
+            id="card-digits"
+            type="text"
+            value={lastDigits}
+            onChange={(e) => setLastDigits(e.target.value.replace(/\D/g, "").slice(0, 4))}
+            placeholder="e.g. 4567"
+            maxLength={4}
+            pattern="\d{0,4}"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="card-brand" className="block text-xs text-gray-600">
+            Brand
+          </label>
+          <select
+            id="card-brand"
+            value={brand}
+            onChange={(e) => setBrand(e.target.value)}
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            <option value="">Select...</option>
+            <option value="Visa">Visa</option>
+            <option value="Mastercard">Mastercard</option>
+            <option value="Elo">Elo</option>
+            <option value="Amex">Amex</option>
+            <option value="Hipercard">Hipercard</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-600">{error}</p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isSubmitting || !label.trim()}
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isSubmitting ? "Encrypting & saving..." : "Save card"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md bg-gray-100 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/dashboard/src/pages/DashboardPage.tsx
+++ b/dashboard/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { listCards, listTransactions } from "../lib/api";
 import { decrypt } from "../lib/crypto";
+import { decryptCard, formatCardLabel } from "../lib/card-data";
 import { filterTransactions } from "../lib/filters";
 import {
   sortByDateDescending,
@@ -116,7 +117,7 @@ function formatBRL(value: number): string {
 }
 
 export function DashboardPage() {
-  const { token } = useAuth();
+  const { token, dek } = useAuth();
   const { filters, updateFilter, clearFilters, hasActiveFilters } =
     useFilters();
 
@@ -135,6 +136,23 @@ export function DashboardPage() {
     queryFn: () => listCards(token!),
     enabled: !!token,
   });
+
+  const decryptedCards = useQuery({
+    queryKey: ["cards:decrypted", cards.data?.length],
+    queryFn: async () => {
+      if (!cards.data || !dek) return [];
+      return Promise.all(cards.data.map((c) => decryptCard(c, dek)));
+    },
+    enabled: !!cards.data && !!dek,
+  });
+
+  const cardLabels = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of decryptedCards.data ?? []) {
+      map.set(c.id, formatCardLabel(c.label, c.last_digits));
+    }
+    return map;
+  }, [decryptedCards.data]);
 
   const { data: allTransactions, isLoading, isError, error } =
     useDecryptedTransactions();
@@ -243,6 +261,7 @@ export function DashboardPage() {
         onClear={clearFilters}
         hasActiveFilters={hasActiveFilters}
         transactions={allTransactions}
+        cardLabels={cardLabels}
       />
 
       {/* Transaction list */}
@@ -295,7 +314,7 @@ export function DashboardPage() {
                     {tx.category}
                     {" · "}
                     <span className="text-gray-400">
-                      {tx.card_id.slice(0, 8)}...
+                      {cardLabels.get(tx.card_id) ?? `${tx.card_id.slice(0, 8)}...`}
                     </span>
                   </p>
                 </div>

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -35,6 +35,13 @@ export interface Card {
   created_at: string;
 }
 
+/** Payload for creating a new card (encrypted client-side). */
+export interface CreateCardRequest {
+  encrypted_data: string;
+  iv: string;
+  auth_tag: string;
+}
+
 /** Transaction as returned by the API (encrypted). */
 export interface Transaction {
   id: string;


### PR DESCRIPTION
## Summary
- Add card management page (`/cards`) with encrypted card list, add form, and delete with confirmation
- Card selector in dashboard FilterBar now shows decrypted card names instead of truncated UUIDs
- Transaction list shows card labels instead of raw IDs
- Client-side encryption (AES-256-GCM) for new cards before POST to API

## Acceptance Criteria (Issue #25)
- [x] Card list showing decrypted card names and last digits
- [x] Add card form (encrypts client-side before POST)
- [x] Delete card with confirmation
- [x] Visual card selector for filtering transactions

## Files Changed
- **New:** `CardsPage.tsx`, `card-data.ts`, `card-data.test.ts`, `api.test.ts`
- **Modified:** `App.tsx`, `Layout.tsx`, `FilterBar.tsx`, `DashboardPage.tsx`, `api.ts`, `crypto.ts`, `crypto.test.ts`, `types/api.ts`

## Test plan
- [x] 93 tests passing across 7 test files
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean
- [ ] Manual test: navigate to `/cards`, verify card list renders
- [ ] Manual test: add a new card, verify encryption and persistence
- [ ] Manual test: delete a card with confirmation dialog
- [ ] Manual test: verify card names appear in dashboard FilterBar and transaction list

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)