### PR TITLE
feat(dashboard): add dark mode with system preference detection

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -21,6 +21,27 @@
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192x192.png" />
+
+    <!--
+      Prevent FOUC by applying the dark class before the React app boots.
+      Mirrors the resolution logic in src/hooks/useTheme.ts.
+    -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem("cardpulse:theme");
+          var mode = stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+          var isDark =
+            mode === "dark" ||
+            (mode === "system" &&
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (isDark) document.documentElement.classList.add("dark");
+        } catch (e) {
+          /* ignore — defaults to light */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/src/components/CategoryEditor.tsx
+++ b/dashboard/src/components/CategoryEditor.tsx
@@ -108,10 +108,10 @@ export function CategoryEditor({
   if (isSaving) {
     return (
       <span
-        className="inline-flex items-center gap-1 text-xs text-gray-400"
+        className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500"
         data-testid="category-saving"
       >
-        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500" />
+        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500 dark:border-gray-600 dark:border-t-blue-400" />
         Saving...
       </span>
     );
@@ -128,7 +128,7 @@ export function CategoryEditor({
           onChange={(e) => setValue(e.target.value)}
           onBlur={handleSave}
           onKeyDown={handleKeyDown}
-          className="w-28 rounded border border-blue-400 px-1.5 py-0.5 text-xs text-gray-900 shadow-sm focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          className="w-28 rounded border border-blue-400 px-1.5 py-0.5 text-xs text-gray-900 shadow-sm focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-blue-500 dark:bg-gray-800 dark:text-gray-100"
           placeholder="Category..."
           data-testid="category-input"
         />
@@ -147,8 +147,8 @@ export function CategoryEditor({
       onClick={() => setIsEditing(true)}
       className={`inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs transition-colors ${
         category === "uncategorized"
-          ? "bg-amber-50 text-amber-700 hover:bg-amber-100"
-          : "bg-blue-50 text-blue-700 hover:bg-blue-100"
+          ? "bg-amber-50 text-amber-700 hover:bg-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-900/50"
+          : "bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-900/50"
       }`}
       title="Click to change category"
       data-testid="category-label"

--- a/dashboard/src/components/FilterBar.tsx
+++ b/dashboard/src/components/FilterBar.tsx
@@ -43,13 +43,13 @@ export function FilterBar({
   const cardIds = uniqueValues(transactions, "card_id");
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4">
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
       <div className="flex flex-wrap items-end gap-3">
         {/* Search */}
         <div className="min-w-[200px] flex-1">
           <label
             htmlFor="search"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Search
           </label>
@@ -59,7 +59,7 @@ export function FilterBar({
             value={filters.search ?? ""}
             onChange={(e) => onFilterChange("search", e.target.value || undefined)}
             placeholder="Merchant name..."
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
@@ -67,7 +67,7 @@ export function FilterBar({
         <div className="min-w-[130px]">
           <label
             htmlFor="month"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Month
           </label>
@@ -75,7 +75,7 @@ export function FilterBar({
             id="month"
             value={filters.month ?? ""}
             onChange={(e) => onFilterChange("month", e.target.value || undefined)}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           >
             <option value="">All months</option>
             {months.map((m) => (
@@ -90,7 +90,7 @@ export function FilterBar({
         <div className="min-w-[130px]">
           <label
             htmlFor="card"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Card
           </label>
@@ -100,7 +100,7 @@ export function FilterBar({
             onChange={(e) =>
               onFilterChange("cardId", e.target.value || undefined)
             }
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           >
             <option value="">All cards</option>
             {cardIds.map((c) => (
@@ -115,7 +115,7 @@ export function FilterBar({
         <div className="min-w-[130px]">
           <label
             htmlFor="category"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Category
           </label>
@@ -125,7 +125,7 @@ export function FilterBar({
             onChange={(e) =>
               onFilterChange("category", e.target.value || undefined)
             }
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           >
             <option value="">All categories</option>
             {categories.map((c) => (
@@ -140,7 +140,7 @@ export function FilterBar({
         <div className="min-w-[90px]">
           <label
             htmlFor="amountMin"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Min R$
           </label>
@@ -157,14 +157,14 @@ export function FilterBar({
               )
             }
             placeholder="0"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
         <div className="min-w-[90px]">
           <label
             htmlFor="amountMax"
-            className="block text-xs font-medium text-gray-500"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
           >
             Max R$
           </label>
@@ -181,7 +181,7 @@ export function FilterBar({
               )
             }
             placeholder="999"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
@@ -189,7 +189,7 @@ export function FilterBar({
         {hasActiveFilters && (
           <button
             onClick={onClear}
-            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
           >
             Clear all
           </button>

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -3,56 +3,63 @@ import { Outlet, Link } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import { RotateKeyModal } from "./RotateKeyModal";
 import { OfflineIndicator } from "./OfflineIndicator";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Layout() {
   const { isAuthenticated, isUnlocked, logout } = useAuth();
   const [showRotateModal, setShowRotateModal] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <OfflineIndicator />
-      <nav className="border-b border-gray-200 bg-white">
+      <nav className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-          <Link to="/" className="text-xl font-semibold text-gray-900">
+          <Link
+            to="/"
+            className="text-xl font-semibold text-gray-900 dark:text-gray-100"
+          >
             CardPulse
           </Link>
 
-          {isAuthenticated && (
-            <div className="flex items-center gap-4">
-              <Link
-                to="/"
-                className="text-sm text-gray-600 hover:text-gray-900"
-              >
-                Dashboard
-              </Link>
-              <Link
-                to="/transactions"
-                className="text-sm text-gray-600 hover:text-gray-900"
-              >
-                Transactions
-              </Link>
-              <Link
-                to="/cards"
-                className="text-sm text-gray-600 hover:text-gray-900"
-              >
-                Cards
-              </Link>
-              {isUnlocked && (
-                <button
-                  onClick={() => setShowRotateModal(true)}
-                  className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+          <div className="flex items-center gap-4">
+            {isAuthenticated && (
+              <>
+                <Link
+                  to="/"
+                  className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                 >
-                  Change password
+                  Dashboard
+                </Link>
+                <Link
+                  to="/transactions"
+                  className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                >
+                  Transactions
+                </Link>
+                <Link
+                  to="/cards"
+                  className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                >
+                  Cards
+                </Link>
+                {isUnlocked && (
+                  <button
+                    onClick={() => setShowRotateModal(true)}
+                    className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    Change password
+                  </button>
+                )}
+                <button
+                  onClick={logout}
+                  className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Logout
                 </button>
-              )}
-              <button
-                onClick={logout}
-                className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
-              >
-                Logout
-              </button>
-            </div>
-          )}
+              </>
+            )}
+            <ThemeToggle />
+          </div>
         </div>
       </nav>
 

--- a/dashboard/src/components/RotateKeyModal.tsx
+++ b/dashboard/src/components/RotateKeyModal.tsx
@@ -103,19 +103,19 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-lg">
+      <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-lg dark:border-gray-800 dark:bg-gray-900">
         {step === "success" ? (
           <div className="text-center">
-            <h2 className="text-xl font-semibold text-gray-900">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Password rotated
             </h2>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
               Your master password has been updated successfully. Use the new
               password next time you unlock your data.
             </p>
             <button
               onClick={onClose}
-              className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
             >
               Done
             </button>
@@ -123,10 +123,10 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
         ) : (
           <>
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-gray-900">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
                 Change master password
               </h2>
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                 {step === "old-password"
                   ? "Enter your current master password to verify your identity."
                   : "Choose a new master password. Your encrypted data will remain intact."}
@@ -138,7 +138,7 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                 <div>
                   <label
                     htmlFor="old-master-password"
-                    className="block text-sm font-medium text-gray-700"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     Current master password
                   </label>
@@ -149,12 +149,12 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                     autoFocus
                     value={oldPassword}
                     onChange={(e) => setOldPassword(e.target.value)}
-                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   />
                 </div>
 
                 {error && (
-                  <p className="rounded-md bg-red-50 p-2 text-sm text-red-600">
+                  <p className="rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/40 dark:text-red-300">
                     {error}
                   </p>
                 )}
@@ -163,14 +163,14 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                   <button
                     type="button"
                     onClick={onClose}
-                    className="flex-1 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+                    className="flex-1 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
                     disabled={loading}
-                    className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                    className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
                   >
                     {loading ? "Verifying..." : "Continue"}
                   </button>
@@ -181,7 +181,7 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                 <div>
                   <label
                     htmlFor="new-master-password"
-                    className="block text-sm font-medium text-gray-700"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     New master password
                   </label>
@@ -193,14 +193,14 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                     minLength={8}
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
-                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   />
                 </div>
 
                 <div>
                   <label
                     htmlFor="confirm-master-password"
-                    className="block text-sm font-medium text-gray-700"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     Confirm new master password
                   </label>
@@ -211,12 +211,12 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                     minLength={8}
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   />
                 </div>
 
                 {error && (
-                  <p className="rounded-md bg-red-50 p-2 text-sm text-red-600">
+                  <p className="rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/40 dark:text-red-300">
                     {error}
                   </p>
                 )}
@@ -225,14 +225,14 @@ export function RotateKeyModal({ onClose }: RotateKeyModalProps) {
                   <button
                     type="button"
                     onClick={onClose}
-                    className="flex-1 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+                    className="flex-1 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
                     disabled={loading}
-                    className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                    className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
                   >
                     {loading ? "Rotating..." : "Rotate key"}
                   </button>

--- a/dashboard/src/components/SpendingCharts.tsx
+++ b/dashboard/src/components/SpendingCharts.tsx
@@ -5,6 +5,9 @@
  * - Monthly bar chart: total spending per month
  * - Category pie chart: spending distribution by category
  * - Daily trend line: spending over time within the filtered period
+ *
+ * Chart colors adapt to the active theme via the `useTheme` hook so the
+ * grids, axes, and tooltips remain legible in both light and dark mode.
  */
 
 import {
@@ -28,6 +31,7 @@ import {
   aggregateByCategory,
   aggregateByDay,
 } from "../lib/chart-data";
+import { useTheme, type ResolvedTheme } from "../hooks/useTheme";
 
 /** Color palette for pie chart slices. */
 const COLORS = [
@@ -42,6 +46,26 @@ const COLORS = [
   "#14b8a6", // teal
   "#6366f1", // indigo
 ];
+
+/** Returns a theme-appropriate palette for axes, grid, and tooltips. */
+function chartPalette(theme: ResolvedTheme) {
+  if (theme === "dark") {
+    return {
+      grid: "#374151", // gray-700
+      axis: "#9ca3af", // gray-400
+      tooltipBg: "#1f2937", // gray-800
+      tooltipBorder: "#374151",
+      tooltipText: "#f3f4f6", // gray-100
+    };
+  }
+  return {
+    grid: "#f0f0f0",
+    axis: "#9ca3af",
+    tooltipBg: "#ffffff",
+    tooltipBorder: "#e5e7eb",
+    tooltipText: "#111827",
+  };
+}
 
 /** Formats amount as compact BRL for chart tooltips. */
 function formatBRL(value: number): string {
@@ -59,6 +83,17 @@ export function SpendingCharts({ transactions }: SpendingChartsProps) {
   const monthlyData = aggregateByMonth(transactions);
   const categoryData = aggregateByCategory(transactions);
   const dailyData = aggregateByDay(transactions);
+  const { resolvedTheme } = useTheme();
+  const palette = chartPalette(resolvedTheme);
+
+  const tooltipStyle = {
+    borderRadius: "8px",
+    border: `1px solid ${palette.tooltipBorder}`,
+    backgroundColor: palette.tooltipBg,
+    color: palette.tooltipText,
+  } as const;
+  const tooltipItemStyle = { color: palette.tooltipText };
+  const tooltipLabelStyle = { color: palette.tooltipText };
 
   if (transactions.length === 0) {
     return null;
@@ -67,40 +102,43 @@ export function SpendingCharts({ transactions }: SpendingChartsProps) {
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {/* Monthly bar chart */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h3 className="mb-4 text-sm font-medium text-gray-700">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+        <h3 className="mb-4 text-sm font-medium text-gray-700 dark:text-gray-200">
           Monthly Spending
         </h3>
         {monthlyData.length > 0 ? (
           <ResponsiveContainer width="100%" height={250}>
             <BarChart data={monthlyData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <CartesianGrid strokeDasharray="3 3" stroke={palette.grid} />
               <XAxis
                 dataKey="month"
-                tick={{ fontSize: 12 }}
-                stroke="#9ca3af"
+                tick={{ fontSize: 12, fill: palette.axis }}
+                stroke={palette.axis}
               />
-              <YAxis tick={{ fontSize: 12 }} stroke="#9ca3af" />
+              <YAxis
+                tick={{ fontSize: 12, fill: palette.axis }}
+                stroke={palette.axis}
+              />
               <Tooltip
                 formatter={(value) => [formatBRL(Number(value)), "Total"]}
-                contentStyle={{
-                  borderRadius: "8px",
-                  border: "1px solid #e5e7eb",
-                }}
+                contentStyle={tooltipStyle}
+                itemStyle={tooltipItemStyle}
+                labelStyle={tooltipLabelStyle}
+                cursor={{ fill: palette.grid, fillOpacity: 0.3 }}
               />
               <Bar dataKey="total" fill="#3b82f6" radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         ) : (
-          <p className="py-8 text-center text-sm text-gray-400">
+          <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
             No data available
           </p>
         )}
       </div>
 
       {/* Category pie chart */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h3 className="mb-4 text-sm font-medium text-gray-700">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+        <h3 className="mb-4 text-sm font-medium text-gray-700 dark:text-gray-200">
           By Category
         </h3>
         {categoryData.length > 0 ? (
@@ -127,44 +165,48 @@ export function SpendingCharts({ transactions }: SpendingChartsProps) {
               </Pie>
               <Tooltip
                 formatter={(value) => [formatBRL(Number(value)), "Total"]}
-                contentStyle={{
-                  borderRadius: "8px",
-                  border: "1px solid #e5e7eb",
-                }}
+                contentStyle={tooltipStyle}
+                itemStyle={tooltipItemStyle}
+                labelStyle={tooltipLabelStyle}
               />
-              <Legend />
+              <Legend
+                wrapperStyle={{ color: palette.axis }}
+              />
             </PieChart>
           </ResponsiveContainer>
         ) : (
-          <p className="py-8 text-center text-sm text-gray-400">
+          <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
             No data available
           </p>
         )}
       </div>
 
       {/* Daily trend line */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4 lg:col-span-2">
-        <h3 className="mb-4 text-sm font-medium text-gray-700">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 lg:col-span-2 dark:border-gray-800 dark:bg-gray-900">
+        <h3 className="mb-4 text-sm font-medium text-gray-700 dark:text-gray-200">
           Daily Spending Trend
         </h3>
         {dailyData.length > 0 ? (
           <ResponsiveContainer width="100%" height={250}>
             <LineChart data={dailyData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <CartesianGrid strokeDasharray="3 3" stroke={palette.grid} />
               <XAxis
                 dataKey="day"
-                tick={{ fontSize: 11 }}
-                stroke="#9ca3af"
+                tick={{ fontSize: 11, fill: palette.axis }}
+                stroke={palette.axis}
                 tickFormatter={(day: string) => day.slice(5)}
               />
-              <YAxis tick={{ fontSize: 12 }} stroke="#9ca3af" />
+              <YAxis
+                tick={{ fontSize: 12, fill: palette.axis }}
+                stroke={palette.axis}
+              />
               <Tooltip
                 formatter={(value) => [formatBRL(Number(value)), "Total"]}
                 labelFormatter={(day) => `Date: ${String(day)}`}
-                contentStyle={{
-                  borderRadius: "8px",
-                  border: "1px solid #e5e7eb",
-                }}
+                contentStyle={tooltipStyle}
+                itemStyle={tooltipItemStyle}
+                labelStyle={tooltipLabelStyle}
+                cursor={{ stroke: palette.grid }}
               />
               <Line
                 type="monotone"
@@ -177,7 +219,7 @@ export function SpendingCharts({ transactions }: SpendingChartsProps) {
             </LineChart>
           </ResponsiveContainer>
         ) : (
-          <p className="py-8 text-center text-sm text-gray-400">
+          <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
             No data available
           </p>
         )}

--- a/dashboard/src/components/ThemeToggle.tsx
+++ b/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,100 @@
+/**
+ * ThemeToggle — button that cycles through light, dark, and system themes.
+ *
+ * Renders an icon and accessible label reflecting the user's current mode.
+ * Clicking advances to the next mode in the cycle (`light → dark → system`).
+ */
+
+import { useTheme, type ThemeMode } from "../hooks/useTheme";
+
+const NEXT_LABEL: Record<ThemeMode, string> = {
+  light: "Switch to dark theme",
+  dark: "Switch to system theme",
+  system: "Switch to light theme",
+};
+
+const MODE_LABEL: Record<ThemeMode, string> = {
+  light: "Light",
+  dark: "Dark",
+  system: "System",
+};
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function MonitorIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
+  );
+}
+
+function modeIcon(mode: ThemeMode) {
+  if (mode === "light") return <SunIcon />;
+  if (mode === "dark") return <MoonIcon />;
+  return <MonitorIcon />;
+}
+
+export function ThemeToggle() {
+  const { mode, toggle } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      title={NEXT_LABEL[mode]}
+      aria-label={NEXT_LABEL[mode]}
+      data-testid="theme-toggle"
+      className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+    >
+      {modeIcon(mode)}
+      <span className="hidden sm:inline">{MODE_LABEL[mode]}</span>
+    </button>
+  );
+}

--- a/dashboard/src/hooks/useTheme.test.ts
+++ b/dashboard/src/hooks/useTheme.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+/**
+ * Tests for useTheme — hook that manages light/dark theme preference.
+ *
+ * Behavior:
+ *  - Resolves the active theme from a stored mode (`light` | `dark` | `system`).
+ *  - In `system` mode, reads `prefers-color-scheme: dark` and updates live.
+ *  - Persists the user's chosen mode to localStorage.
+ *  - Toggles the `dark` class on the documentElement.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTheme, THEME_STORAGE_KEY } from "./useTheme";
+
+// Vitest's jsdom environment exposes a non-functional `window.localStorage`
+// stub. Replace it with an in-memory shim so the hook (which persists the
+// chosen mode) can be exercised end-to-end in tests.
+function installLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  const fake: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => void store.delete(key),
+    setItem: (key, value) => void store.set(key, String(value)),
+  };
+  Object.defineProperty(window, "localStorage", {
+    writable: true,
+    configurable: true,
+    value: fake,
+  });
+  return fake;
+}
+
+type MqlListener = (e: { matches: boolean }) => void;
+
+interface MockMql {
+  matches: boolean;
+  media: string;
+  addEventListener: (type: "change", listener: MqlListener) => void;
+  removeEventListener: (type: "change", listener: MqlListener) => void;
+  dispatch: (matches: boolean) => void;
+}
+
+function installMatchMedia(initialMatches: boolean): MockMql {
+  const listeners: MqlListener[] = [];
+  const mql: MockMql = {
+    matches: initialMatches,
+    media: "(prefers-color-scheme: dark)",
+    addEventListener: (_type, listener) => {
+      listeners.push(listener);
+    },
+    removeEventListener: (_type, listener) => {
+      const idx = listeners.indexOf(listener);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+    dispatch: (matches: boolean) => {
+      mql.matches = matches;
+      for (const l of listeners) l({ matches });
+    },
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation(() => mql),
+  });
+
+  return mql;
+}
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    installLocalStorage();
+    document.documentElement.classList.remove("dark");
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("defaults to system mode when no preference is stored", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe("system");
+  });
+
+  it("resolves to dark when system preference is dark and mode is system", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe("system");
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("resolves to light when system preference is light and mode is system", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.resolvedTheme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("respects an explicit dark preference even when system is light", () => {
+    installMatchMedia(false);
+    window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("respects an explicit light preference even when system is dark", () => {
+    installMatchMedia(true);
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.mode).toBe("light");
+    expect(result.current.resolvedTheme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("persists the chosen mode to localStorage when setMode is called", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setMode("dark");
+    });
+
+    expect(result.current.mode).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("reacts to system theme changes when in system mode", () => {
+    const mql = installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.resolvedTheme).toBe("light");
+
+    act(() => {
+      mql.dispatch(true);
+    });
+
+    expect(result.current.resolvedTheme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("ignores system theme changes when an explicit mode is set", () => {
+    const mql = installMatchMedia(false);
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setMode("light");
+    });
+
+    act(() => {
+      mql.dispatch(true);
+    });
+
+    expect(result.current.resolvedTheme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("toggle cycles light → dark → system", () => {
+    installMatchMedia(false);
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.mode).toBe("light");
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.mode).toBe("dark");
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.mode).toBe("system");
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.mode).toBe("light");
+  });
+});

--- a/dashboard/src/hooks/useTheme.ts
+++ b/dashboard/src/hooks/useTheme.ts
@@ -1,0 +1,113 @@
+/**
+ * useTheme — manages light/dark theme preference for the dashboard.
+ *
+ * Supports three modes:
+ *  - `light`  — force light theme
+ *  - `dark`   — force dark theme
+ *  - `system` — follow the OS `prefers-color-scheme` media query (default)
+ *
+ * The chosen mode is persisted to localStorage. The resolved theme is
+ * applied by toggling the `dark` class on the document element, which
+ * pairs with Tailwind v4's class-based dark variant configured in
+ * `index.css`.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+/** localStorage key under which the user's chosen mode is stored. */
+export const THEME_STORAGE_KEY = "cardpulse:theme";
+
+/** Reads the stored mode, falling back to `system` for unknown/missing values. */
+function readStoredMode(): ThemeMode {
+  if (typeof window === "undefined") return "system";
+  const value = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (value === "light" || value === "dark" || value === "system") {
+    return value;
+  }
+  return "system";
+}
+
+/** Returns the system preference for dark mode (`true` if dark). */
+function systemPrefersDark(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+/** Resolves a mode + system preference into a concrete light/dark value. */
+function resolveTheme(mode: ThemeMode, systemDark: boolean): ResolvedTheme {
+  if (mode === "system") return systemDark ? "dark" : "light";
+  return mode;
+}
+
+/** Toggles the `dark` class on the document element. */
+function applyThemeClass(theme: ResolvedTheme): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+interface UseThemeReturn {
+  /** The current user-chosen mode (`light`, `dark`, or `system`). */
+  mode: ThemeMode;
+  /** The concrete theme actually being rendered. */
+  resolvedTheme: ResolvedTheme;
+  /** Updates and persists the mode. */
+  setMode: (mode: ThemeMode) => void;
+  /** Cycles through `light → dark → system → light`. */
+  toggle: () => void;
+}
+
+export function useTheme(): UseThemeReturn {
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredMode());
+  const [systemDark, setSystemDark] = useState<boolean>(() => systemPrefersDark());
+
+  // Subscribe to OS-level theme changes so `system` mode stays live.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent | { matches: boolean }) => {
+      setSystemDark(e.matches);
+    };
+    mql.addEventListener("change", handler as (e: MediaQueryListEvent) => void);
+    return () => {
+      mql.removeEventListener(
+        "change",
+        handler as (e: MediaQueryListEvent) => void,
+      );
+    };
+  }, []);
+
+  const resolvedTheme = resolveTheme(mode, systemDark);
+
+  // Apply the resolved theme to the DOM whenever it changes.
+  useEffect(() => {
+    applyThemeClass(resolvedTheme);
+  }, [resolvedTheme]);
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setModeState((current) => {
+      const next: ThemeMode =
+        current === "light" ? "dark" : current === "dark" ? "system" : "light";
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      }
+      return next;
+    });
+  }, []);
+
+  return { mode, resolvedTheme, setMode, toggle };
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,7 +1,10 @@
 @import "tailwindcss";
 
+/* Tailwind v4 dark mode opt-in via the `dark` class on <html>. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 body {
-  @apply bg-gray-50 text-gray-900 antialiased;
+  @apply bg-gray-50 text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100;
   font-family:
     Inter,
     system-ui,

--- a/dashboard/src/pages/CardsPage.tsx
+++ b/dashboard/src/pages/CardsPage.tsx
@@ -78,8 +78,10 @@ export function CardsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">Cards</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            Cards
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Manage your tracked credit cards &middot;{" "}
             {cards.length} card{cards.length !== 1 ? "s" : ""}
           </p>
@@ -87,7 +89,7 @@ export function CardsPage() {
         <button
           onClick={() => setShowForm(true)}
           disabled={showForm}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
         >
           Add card
         </button>
@@ -104,31 +106,33 @@ export function CardsPage() {
       )}
 
       {/* Card list */}
-      <div className="rounded-lg border border-gray-200 bg-white">
-        <div className="border-b border-gray-200 px-4 py-3">
-          <h2 className="text-lg font-medium text-gray-900">Your cards</h2>
+      <div className="rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+        <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+          <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+            Your cards
+          </h2>
         </div>
 
         {isLoading ? (
-          <p className="p-4 text-sm text-gray-500">
+          <p className="p-4 text-sm text-gray-500 dark:text-gray-400">
             Loading and decrypting...
           </p>
         ) : cards.length === 0 ? (
-          <p className="p-4 text-center text-sm text-gray-500">
+          <p className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
             No cards yet. Add your first card to get started.
           </p>
         ) : (
-          <ul className="divide-y divide-gray-100">
+          <ul className="divide-y divide-gray-100 dark:divide-gray-800">
             {cards.map((card) => (
               <li
                 key={card.id}
                 className="flex items-center justify-between px-4 py-3"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                     {formatCardLabel(card.label, card.last_digits)}
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     {card.brand || "No brand"}
                     {" · "}
                     Added {new Date(card.created_at).toLocaleDateString("pt-BR")}
@@ -137,7 +141,9 @@ export function CardsPage() {
 
                 {deleteConfirmId === card.id ? (
                   <div className="ml-4 flex items-center gap-2">
-                    <span className="text-xs text-red-600">Delete?</span>
+                    <span className="text-xs text-red-600 dark:text-red-400">
+                      Delete?
+                    </span>
                     <button
                       onClick={() => deleteMutation.mutate(card.id)}
                       disabled={deleteMutation.isPending}
@@ -147,7 +153,7 @@ export function CardsPage() {
                     </button>
                     <button
                       onClick={() => setDeleteConfirmId(null)}
-                      className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200"
+                      className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                     >
                       No
                     </button>
@@ -155,7 +161,7 @@ export function CardsPage() {
                 ) : (
                   <button
                     onClick={() => setDeleteConfirmId(card.id)}
-                    className="ml-4 rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                    className="ml-4 rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/40"
                   >
                     Delete
                   </button>
@@ -167,7 +173,7 @@ export function CardsPage() {
       </div>
 
       {isError && (
-        <p className="text-sm text-red-600">
+        <p className="text-sm text-red-600 dark:text-red-400">
           Failed to load cards: {error?.message}
         </p>
       )}
@@ -204,13 +210,18 @@ function AddCardForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3"
+      className="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3 dark:border-blue-900 dark:bg-blue-950/40"
     >
-      <h3 className="text-sm font-medium text-gray-900">Add new card</h3>
+      <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+        Add new card
+      </h3>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <div>
-          <label htmlFor="card-label" className="block text-xs text-gray-600">
+          <label
+            htmlFor="card-label"
+            className="block text-xs text-gray-600 dark:text-gray-300"
+          >
             Card name *
           </label>
           <input
@@ -220,12 +231,15 @@ function AddCardForm({
             onChange={(e) => setLabel(e.target.value)}
             placeholder="e.g. Nubank Platinum"
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
         <div>
-          <label htmlFor="card-digits" className="block text-xs text-gray-600">
+          <label
+            htmlFor="card-digits"
+            className="block text-xs text-gray-600 dark:text-gray-300"
+          >
             Last 4 digits
           </label>
           <input
@@ -236,19 +250,22 @@ function AddCardForm({
             placeholder="e.g. 4567"
             maxLength={4}
             pattern="\d{0,4}"
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
         <div>
-          <label htmlFor="card-brand" className="block text-xs text-gray-600">
+          <label
+            htmlFor="card-brand"
+            className="block text-xs text-gray-600 dark:text-gray-300"
+          >
             Brand
           </label>
           <select
             id="card-brand"
             value={brand}
             onChange={(e) => setBrand(e.target.value)}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
           >
             <option value="">Select...</option>
             <option value="Visa">Visa</option>
@@ -261,21 +278,21 @@ function AddCardForm({
       </div>
 
       {error && (
-        <p className="text-xs text-red-600">{error}</p>
+        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
       )}
 
       <div className="flex gap-2">
         <button
           type="submit"
           disabled={isSubmitting || !label.trim()}
-          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
         >
           {isSubmitting ? "Encrypting & saving..." : "Save card"}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-md bg-gray-100 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+          className="rounded-md bg-gray-100 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
         >
           Cancel
         </button>

--- a/dashboard/src/pages/DashboardPage.tsx
+++ b/dashboard/src/pages/DashboardPage.tsx
@@ -230,8 +230,10 @@ export function DashboardPage() {
       {/* Header with month navigation */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            Dashboard
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             All data is decrypted client-side &middot;{" "}
             {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
           </p>
@@ -241,7 +243,7 @@ export function DashboardPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={goToPreviousMonth}
-            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
             aria-label="Previous month"
           >
             &larr;
@@ -250,15 +252,15 @@ export function DashboardPage() {
             onClick={goToCurrentMonth}
             className={`rounded-md px-3 py-1 text-sm font-medium ${
               isCurrentMonth
-                ? "bg-blue-600 text-white"
-                : "border border-gray-300 text-gray-700 hover:bg-gray-50"
+                ? "bg-blue-600 text-white dark:bg-blue-500"
+                : "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
             }`}
           >
             {formatBucket(activeMonth)}
           </button>
           <button
             onClick={goToNextMonth}
-            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
             aria-label="Next month"
           >
             &rarr;
@@ -308,12 +310,12 @@ export function DashboardPage() {
       />
 
       {/* Transaction list */}
-      <div className="rounded-lg border border-gray-200 bg-white">
-        <div className="border-b border-gray-200 px-4 py-3">
-          <h2 className="text-lg font-medium text-gray-900">
+      <div className="rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+        <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+          <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
             Transactions
             {hasActiveFilters && (
-              <span className="ml-2 text-sm font-normal text-gray-500">
+              <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
                 ({filtered.length} of {allTransactions.length})
               </span>
             )}
@@ -321,12 +323,12 @@ export function DashboardPage() {
         </div>
 
         {isLoading ? (
-          <p className="p-4 text-sm text-gray-500">
+          <p className="p-4 text-sm text-gray-500 dark:text-gray-400">
             Loading and decrypting...
           </p>
         ) : filtered.length === 0 ? (
           <div className="p-4 text-center">
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
               {hasActiveFilters
                 ? "No transactions match your filters."
                 : "No transactions yet."}
@@ -334,24 +336,24 @@ export function DashboardPage() {
             {hasActiveFilters && (
               <button
                 onClick={clearFilters}
-                className="mt-2 text-sm text-blue-600 hover:text-blue-800"
+                className="mt-2 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
               >
                 Clear all filters
               </button>
             )}
           </div>
         ) : (
-          <ul className="divide-y divide-gray-100">
+          <ul className="divide-y divide-gray-100 dark:divide-gray-800">
             {filtered.map((tx) => (
               <li
                 key={tx.id}
                 className="flex items-center justify-between px-4 py-3"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-gray-900">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
                     {tx.merchant}
                   </p>
-                  <p className="flex items-center gap-1 text-xs text-gray-500">
+                  <p className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
                     {formatTransactionDate(tx.created_at)}
                     {" · "}
                     <CategoryEditor
@@ -364,12 +366,12 @@ export function DashboardPage() {
                       categorySource={tx.category_source}
                     />
                     {" · "}
-                    <span className="text-gray-400">
+                    <span className="text-gray-400 dark:text-gray-500">
                       {cardLabels.get(tx.card_id) ?? `${tx.card_id.slice(0, 8)}...`}
                     </span>
                   </p>
                 </div>
-                <span className="ml-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                <span className="ml-4 whitespace-nowrap text-sm font-semibold text-gray-900 dark:text-gray-100">
                   {formatBRL(tx.amount)}
                 </span>
               </li>
@@ -379,7 +381,7 @@ export function DashboardPage() {
       </div>
 
       {isError && (
-        <p className="text-sm text-red-600">
+        <p className="text-sm text-red-600 dark:text-red-400">
           Failed to load transactions: {error?.message}
         </p>
       )}
@@ -397,9 +399,9 @@ function StatCard({
   loading: boolean;
 }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-gray-900">
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
         {loading ? "..." : value}
       </p>
     </div>

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -104,12 +104,12 @@ export function LoginPage() {
   if (step === "master-password") {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
           <div className="mb-6 text-center">
-            <h1 className="text-2xl font-semibold text-gray-900">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
               Unlock your data
             </h1>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
               Enter your master password to decrypt your cards and transactions.
             </p>
           </div>
@@ -118,7 +118,7 @@ export function LoginPage() {
             <div>
               <label
                 htmlFor="master-password"
-                className="block text-sm font-medium text-gray-700"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
               >
                 Master Password
               </label>
@@ -129,13 +129,13 @@ export function LoginPage() {
                 autoFocus
                 value={masterPassword}
                 onChange={(e) => setMasterPassword(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
                 placeholder="Your encryption password"
               />
             </div>
 
             {error && (
-              <p className="rounded-md bg-red-50 p-2 text-sm text-red-600">
+              <p className="rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/40 dark:text-red-300">
                 {error}
               </p>
             )}
@@ -143,7 +143,7 @@ export function LoginPage() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
             >
               {loading ? "Decrypting..." : "Unlock"}
             </button>
@@ -155,7 +155,7 @@ export function LoginPage() {
                 setMasterPassword("");
                 setError(null);
               }}
-              className="w-full text-sm text-gray-500 hover:text-gray-700"
+              className="w-full text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
               Use a different account
             </button>
@@ -167,8 +167,8 @@ export function LoginPage() {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-900">
+      <div className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-900 dark:text-gray-100">
           Sign in to CardPulse
         </h1>
 
@@ -176,7 +176,7 @@ export function LoginPage() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
               Email
             </label>
@@ -186,7 +186,7 @@ export function LoginPage() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
               placeholder="you@example.com"
             />
           </div>
@@ -194,7 +194,7 @@ export function LoginPage() {
           <div>
             <label
               htmlFor="password"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
               Password
             </label>
@@ -204,12 +204,12 @@ export function LoginPage() {
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
             />
           </div>
 
           {error && (
-            <p className="rounded-md bg-red-50 p-2 text-sm text-red-600">
+            <p className="rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/40 dark:text-red-300">
               {error}
             </p>
           )}
@@ -217,7 +217,7 @@ export function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
           >
             {loading ? "Signing in..." : "Sign in"}
           </button>

--- a/dashboard/src/pages/NotFoundPage.tsx
+++ b/dashboard/src/pages/NotFoundPage.tsx
@@ -3,11 +3,13 @@ import { Link } from "react-router-dom";
 export function NotFoundPage() {
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center">
-      <h1 className="text-4xl font-semibold text-gray-900">404</h1>
-      <p className="mt-2 text-gray-500">Page not found</p>
+      <h1 className="text-4xl font-semibold text-gray-900 dark:text-gray-100">
+        404
+      </h1>
+      <p className="mt-2 text-gray-500 dark:text-gray-400">Page not found</p>
       <Link
         to="/"
-        className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
       >
         Go home
       </Link>

--- a/dashboard/src/pages/TransactionsPage.tsx
+++ b/dashboard/src/pages/TransactionsPage.tsx
@@ -261,17 +261,17 @@ export function TransactionsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
             Transactions
           </h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Manage your transactions &middot; {transactions.length} total
           </p>
         </div>
         <button
           onClick={() => setShowForm(true)}
           disabled={showForm}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
         >
           Add transaction
         </button>
@@ -293,33 +293,33 @@ export function TransactionsPage() {
       )}
 
       {/* Transaction list */}
-      <div className="rounded-lg border border-gray-200 bg-white">
-        <div className="border-b border-gray-200 px-4 py-3">
-          <h2 className="text-lg font-medium text-gray-900">
+      <div className="rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+        <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+          <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
             All transactions
           </h2>
         </div>
 
         {isLoading ? (
-          <p className="p-4 text-sm text-gray-500">
+          <p className="p-4 text-sm text-gray-500 dark:text-gray-400">
             Loading and decrypting...
           </p>
         ) : sorted.length === 0 ? (
-          <p className="p-4 text-center text-sm text-gray-500">
+          <p className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
             No transactions yet. Add your first transaction to get started.
           </p>
         ) : (
-          <ul className="divide-y divide-gray-100">
+          <ul className="divide-y divide-gray-100 dark:divide-gray-800">
             {sorted.map((tx) => (
               <li
                 key={tx.id}
                 className="flex items-center justify-between px-4 py-3"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-gray-900">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
                     {tx.merchant}
                   </p>
-                  <p className="flex items-center gap-1 text-xs text-gray-500">
+                  <p className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
                     {formatTransactionDate(tx.created_at)}
                     {" · "}
                     <CategoryEditor
@@ -332,7 +332,7 @@ export function TransactionsPage() {
                       categorySource={tx.category_source}
                     />
                     {" · "}
-                    <span className="text-gray-400">
+                    <span className="text-gray-400 dark:text-gray-500">
                       {cardLabels.get(tx.card_id) ??
                         `${tx.card_id.slice(0, 8)}...`}
                     </span>
@@ -340,13 +340,15 @@ export function TransactionsPage() {
                 </div>
 
                 <div className="ml-4 flex items-center gap-3">
-                  <span className="whitespace-nowrap text-sm font-semibold text-gray-900">
+                  <span className="whitespace-nowrap text-sm font-semibold text-gray-900 dark:text-gray-100">
                     {formatBRL(tx.amount)}
                   </span>
 
                   {deleteConfirmId === tx.id ? (
                     <div className="flex items-center gap-2">
-                      <span className="text-xs text-red-600">Delete?</span>
+                      <span className="text-xs text-red-600 dark:text-red-400">
+                        Delete?
+                      </span>
                       <button
                         onClick={() => deleteMutation.mutate(tx.id)}
                         disabled={deleteMutation.isPending}
@@ -356,7 +358,7 @@ export function TransactionsPage() {
                       </button>
                       <button
                         onClick={() => setDeleteConfirmId(null)}
-                        className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200"
+                        className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                       >
                         No
                       </button>
@@ -364,7 +366,7 @@ export function TransactionsPage() {
                   ) : (
                     <button
                       onClick={() => setDeleteConfirmId(tx.id)}
-                      className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                      className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/40"
                     >
                       Delete
                     </button>
@@ -377,7 +379,7 @@ export function TransactionsPage() {
       </div>
 
       {isError && (
-        <p className="text-sm text-red-600">
+        <p className="text-sm text-red-600 dark:text-red-400">
           Failed to load transactions: {error?.message}
         </p>
       )}
@@ -428,16 +430,16 @@ function AddTransactionForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="space-y-3 rounded-lg border border-blue-200 bg-blue-50 p-4"
+      className="space-y-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950/40"
     >
-      <h3 className="text-sm font-medium text-gray-900">
+      <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
         Add new transaction
       </h3>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
         {/* Card selector */}
         <div>
-          <label htmlFor="tx-card" className="block text-xs text-gray-600">
+          <label htmlFor="tx-card" className="block text-xs text-gray-600 dark:text-gray-300">
             Card *
           </label>
           <select
@@ -445,7 +447,7 @@ function AddTransactionForm({
             value={cardId}
             onChange={(e) => setCardId(e.target.value)}
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           >
             {cards.length === 0 && <option value="">No cards available</option>}
             {cards.map((c) => (
@@ -458,7 +460,7 @@ function AddTransactionForm({
 
         {/* Merchant */}
         <div>
-          <label htmlFor="tx-merchant" className="block text-xs text-gray-600">
+          <label htmlFor="tx-merchant" className="block text-xs text-gray-600 dark:text-gray-300">
             Merchant *
           </label>
           <input
@@ -468,13 +470,13 @@ function AddTransactionForm({
             onChange={(e) => setMerchant(e.target.value)}
             placeholder="e.g. Shell"
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
         {/* Amount */}
         <div>
-          <label htmlFor="tx-amount" className="block text-xs text-gray-600">
+          <label htmlFor="tx-amount" className="block text-xs text-gray-600 dark:text-gray-300">
             Amount (R$) *
           </label>
           <input
@@ -486,13 +488,13 @@ function AddTransactionForm({
             onChange={(e) => setAmount(e.target.value)}
             placeholder="0.00"
             required
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
 
         {/* Category */}
         <div>
-          <label htmlFor="tx-category" className="block text-xs text-gray-600">
+          <label htmlFor="tx-category" className="block text-xs text-gray-600 dark:text-gray-300">
             Category
           </label>
           <input
@@ -502,7 +504,7 @@ function AddTransactionForm({
             value={category}
             onChange={(e) => setCategory(e.target.value)}
             placeholder="e.g. food"
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
           <datalist id="tx-category-suggestions">
             {categorySuggestions.map((s) => (
@@ -513,7 +515,7 @@ function AddTransactionForm({
 
         {/* Month bucket */}
         <div>
-          <label htmlFor="tx-bucket" className="block text-xs text-gray-600">
+          <label htmlFor="tx-bucket" className="block text-xs text-gray-600 dark:text-gray-300">
             Month
           </label>
           <input
@@ -521,12 +523,12 @@ function AddTransactionForm({
             type="month"
             value={bucket}
             onChange={(e) => setBucket(e.target.value)}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
           />
         </div>
       </div>
 
-      {error && <p className="text-xs text-red-600">{error}</p>}
+      {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
 
       <div className="flex gap-2">
         <button
@@ -534,14 +536,14 @@ function AddTransactionForm({
           disabled={
             isSubmitting || !merchant.trim() || !amount || !cardId
           }
-          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
         >
           {isSubmitting ? "Encrypting & saving..." : "Save transaction"}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-md bg-gray-100 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+          className="rounded-md bg-gray-100 px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
         >
           Cancel
         </button>


### PR DESCRIPTION
## Summary
- Adds a `useTheme` hook supporting `light` / `dark` / `system` modes, with live OS preference tracking and localStorage persistence (`cardpulse:theme`).
- Introduces a `ThemeToggle` button in the layout header that cycles through the three modes.
- Configures Tailwind v4's class-based dark variant in `index.css` and applies `dark:` classes across pages, forms, the offline indicator host layout, the rotate-key modal, the category editor, and the spending charts (axes, grid, tooltips, legend).
- Adds an inline boot script in `index.html` to apply the resolved theme before React mounts, preventing flash-of-unstyled-content.
- Covers the hook with 9 unit tests (system detection, explicit override, persistence, live media-query updates, toggle cycle).

Closes #37

## Test plan
- [x] `npm run lint` (eslint clean)
- [x] `npx vitest run` — 285/285 tests pass (including 9 new `useTheme` tests)
- [x] `npm run build` — production bundle builds
- [ ] Manual: open dashboard, toggle through Light → Dark → System and confirm all surfaces (login, dashboard, transactions, cards, charts, filters, modals) render correctly in both themes
- [ ] Manual: change OS appearance while in System mode and confirm the dashboard updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)