### PR TITLE
feat(crypto): multi-device DEK sync via QR pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ CardPulse automatically captures credit card purchases from SMS notifications on
   - [Transactions](#transactions)
   - [Key Management](#key-management)
 - [Encryption Model](#encryption-model)
+- [Multi-Device Sync](#multi-device-sync)
 - [iOS Automation](#ios-automation)
 - [Testing](#testing)
 - [Deployment](#deployment)
@@ -489,6 +490,75 @@ flowchart TB
 ### Trade-offs
 
 Since the server cannot read data, all aggregation (totals, charts, category breakdowns) happens client-side after decryption. This is viable for personal use with hundreds of transactions per month. The `timestamp_bucket` field allows server-side filtering by month without decrypting everything.
+
+---
+
+## Multi-Device Sync
+
+CardPulse is designed to be used from any number of devices (multiple browsers, a laptop and a phone, an iPad, etc.) without ever sharing your master password or DEK over the network. Because the **wrapped DEK already lives on the server**, every device can derive the same encryption key locally given just two ingredients:
+
+1. Your account email
+2. Your master password
+
+The server returns the wrapped DEK on every login and the client unwraps it locally. No additional setup, transfer, or key escrow is required.
+
+### Why this is safe
+
+```mermaid
+flowchart LR
+    M["🔑 Master Password\n(in your head only)"]
+    S["📦 Wrapped DEK\n(on server, opaque)"]
+    M -->|"Argon2id"| K["Derived Key"]
+    K -->|"AES-GCM unwrap"| D["DEK"]
+    S --> D
+    D --> R["Decrypted data\n(client only)"]
+```
+
+The server stores the wrapped DEK but never sees the master password or the derived key, so it cannot unwrap it. Anyone who steals the database still has nothing without your password.
+
+### Adding a second device — Web dashboard
+
+There are two equivalent paths:
+
+**Manual login (no setup needed):**
+
+1. Open the dashboard URL on the new device
+2. Enter your email + server password
+3. Enter your master password to unlock — done
+
+**Pair via QR code (faster):**
+
+1. On a device that's already unlocked, click **Sync device** in the header
+2. A modal appears with a QR code containing your email + dashboard URL (never your password or DEK)
+3. Scan the QR with the new device's camera, or copy the link and open it manually
+4. The login form opens with the email pre-filled
+5. Enter your server password and master password to unlock
+
+Behind the scenes the QR encodes a `?pair=<base64url>` query parameter on the dashboard URL. The destination device decodes the payload, validates the schema and `http(s)` URL, and pre-fills the form. Malformed payloads are silently ignored — the user simply sees the normal login screen.
+
+### Adding a second iPhone — Scriptable
+
+The Scriptable script (`ios/scriptable/CardPulse.js`) supports the same flow:
+
+1. Install Scriptable + the CardPulse script on the second iPhone
+2. Run the script with `setup` as the input parameter
+3. Enter the API URL, your email, and your server password (Step 1/2)
+4. Enter your master password (Step 2/2) — Scriptable derives the DEK from the wrapped DEK fetched at login and stores both the JWT and the DEK in the iOS Keychain
+5. Run the script with `cards` to map your card last digits to UUIDs
+
+The wrapped DEK and `dek_params` returned by the API are identical for every device, so all your iPhones, browsers, and the dashboard end up with the exact same DEK without any direct device-to-device transfer.
+
+### Rotating your master password
+
+Rotating the master password (via the **Change password** modal) re-wraps the DEK with new credentials and updates the server copy. After rotation, every other device will need to log in again with the new password — the underlying DEK does not change, so all your existing encrypted data remains decryptable.
+
+### Security checklist
+
+- [x] Master password never sent to the server
+- [x] DEK never sent to the server in unwrapped form
+- [x] Pair QR contains only non-secret metadata (email + API URL)
+- [x] Pair payloads validated against a versioned schema and `http(s)` allow-list
+- [x] Sessions are memory-only — closing the tab forgets the DEK
 
 ---
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.95.2",
+        "@types/qrcode": "^1.5.6",
+        "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
@@ -1585,10 +1587,18 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -2118,7 +2128,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2128,7 +2137,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2252,6 +2260,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001781",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
@@ -2300,6 +2317,17 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2313,7 +2341,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2326,7 +2353,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2545,6 +2571,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2584,6 +2619,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2597,6 +2638,12 @@
       "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2997,6 +3044,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3133,6 +3189,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3744,6 +3809,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3774,7 +3848,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3906,6 +3979,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -4042,6 +4141,15 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4051,6 +4159,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -4136,6 +4250,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -4209,6 +4329,32 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4452,7 +4598,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4750,6 +4895,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4775,6 +4926,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {
@@ -4816,12 +4981,105 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.95.2",
+    "@types/qrcode": "^1.5.6",
+    "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2",

--- a/dashboard/src/components/DeviceSyncModal.tsx
+++ b/dashboard/src/components/DeviceSyncModal.tsx
@@ -1,0 +1,174 @@
+/**
+ * Modal that helps the user log in on a second device.
+ *
+ * Renders a QR code containing a `pair` URL with the current account's
+ * email and API base URL. Scanning the code on a second device opens the
+ * dashboard with the email pre-filled — the user only needs to type their
+ * master password.
+ *
+ * Critical: the QR NEVER contains the master password or DEK. The
+ * zero-knowledge model is preserved.
+ */
+
+import { useEffect, useState } from "react";
+import QRCode from "qrcode";
+import { useAuth } from "../hooks/useAuth";
+import {
+  buildPairUrl,
+  PAIR_PAYLOAD_VERSION,
+  type PairPayload,
+} from "../lib/deviceSync";
+
+interface DeviceSyncModalProps {
+  onClose: () => void;
+}
+
+/** Returns the dashboard origin to use as the destination of the pair URL. */
+function dashboardOrigin(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.origin + window.location.pathname;
+}
+
+/** Returns the API base URL the current dashboard is talking to. */
+function apiBaseUrl(): string {
+  const fromEnv = import.meta.env.VITE_API_URL;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  if (typeof window !== "undefined") return window.location.origin;
+  return "";
+}
+
+export function DeviceSyncModal({ onClose }: DeviceSyncModalProps) {
+  const { email } = useAuth();
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const payload: PairPayload | null = email
+    ? {
+        v: PAIR_PAYLOAD_VERSION,
+        apiBaseUrl: apiBaseUrl(),
+        email,
+      }
+    : null;
+
+  const pairUrl = payload ? buildPairUrl(dashboardOrigin(), payload) : null;
+
+  useEffect(() => {
+    if (!pairUrl) return;
+    let cancelled = false;
+    QRCode.toDataURL(pairUrl, {
+      errorCorrectionLevel: "M",
+      margin: 1,
+      width: 256,
+      color: { dark: "#111827", light: "#ffffff" },
+    })
+      .then((url) => {
+        if (!cancelled) setQrDataUrl(url);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to render QR code",
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pairUrl]);
+
+  async function handleCopy() {
+    if (!pairUrl) return;
+    try {
+      await navigator.clipboard.writeText(pairUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Could not copy link to clipboard.");
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-lg dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Sync to another device
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Your encrypted vault already lives on the server. Any device with
+            your email and master password can decrypt it.
+          </p>
+        </div>
+
+        {!email ? (
+          <p className="rounded-md bg-amber-50 p-3 text-sm text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+            Email not available in this session. Log out and sign in again to
+            generate a pairing code.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col items-center gap-3">
+              {qrDataUrl ? (
+                <img
+                  src={qrDataUrl}
+                  alt="QR code containing your CardPulse pairing link"
+                  className="h-56 w-56 rounded-md border border-gray-200 bg-white p-2 dark:border-gray-700"
+                  data-testid="device-sync-qr"
+                />
+              ) : (
+                <div className="flex h-56 w-56 items-center justify-center rounded-md border border-dashed border-gray-300 text-xs text-gray-400 dark:border-gray-700 dark:text-gray-500">
+                  Generating QR…
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {copied ? "Copied!" : "Copy pairing link"}
+              </button>
+            </div>
+
+            <ol className="mt-5 list-decimal space-y-2 pl-5 text-sm text-gray-700 dark:text-gray-300">
+              <li>
+                On your second device, scan this QR with the camera or open the
+                copied link in a browser.
+              </li>
+              <li>
+                The dashboard will open with your email already filled in.
+              </li>
+              <li>
+                Enter your{" "}
+                <span className="font-medium">server password</span>, then your{" "}
+                <span className="font-medium">master password</span> to unlock
+                your data.
+              </li>
+            </ol>
+
+            <p className="mt-4 rounded-md bg-gray-50 p-3 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+              <span className="font-medium">Privacy note:</span> the QR code
+              contains only your account email and API URL. Your master
+              password and encryption keys never leave this device.
+            </p>
+          </>
+        )}
+
+        {error && (
+          <p className="mt-3 rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-5 w-full rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { Outlet, Link } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import { RotateKeyModal } from "./RotateKeyModal";
+import { DeviceSyncModal } from "./DeviceSyncModal";
 import { OfflineIndicator } from "./OfflineIndicator";
 import { ThemeToggle } from "./ThemeToggle";
 
 export function Layout() {
   const { isAuthenticated, isUnlocked, logout } = useAuth();
   const [showRotateModal, setShowRotateModal] = useState(false);
+  const [showSyncModal, setShowSyncModal] = useState(false);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
@@ -43,12 +45,20 @@ export function Layout() {
                   Cards
                 </Link>
                 {isUnlocked && (
-                  <button
-                    onClick={() => setShowRotateModal(true)}
-                    className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                  >
-                    Change password
-                  </button>
+                  <>
+                    <button
+                      onClick={() => setShowSyncModal(true)}
+                      className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      Sync device
+                    </button>
+                    <button
+                      onClick={() => setShowRotateModal(true)}
+                      className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      Change password
+                    </button>
+                  </>
                 )}
                 <button
                   onClick={logout}
@@ -69,6 +79,10 @@ export function Layout() {
 
       {showRotateModal && (
         <RotateKeyModal onClose={() => setShowRotateModal(false)} />
+      )}
+
+      {showSyncModal && (
+        <DeviceSyncModal onClose={() => setShowSyncModal(false)} />
       )}
     </div>
   );

--- a/dashboard/src/hooks/useAuth.ts
+++ b/dashboard/src/hooks/useAuth.ts
@@ -50,6 +50,7 @@ export function useAuth() {
     session,
     token: session?.token ?? null,
     dek: session?.dek ?? null,
+    email: session?.email ?? null,
     isAuthenticated: checkAuth(),
     isUnlocked: checkUnlocked(),
     login,

--- a/dashboard/src/lib/deviceSync.test.ts
+++ b/dashboard/src/lib/deviceSync.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for deviceSync — multi-device pairing helpers.
+ *
+ * The pairing payload encodes the API URL and email for the source account
+ * (NEVER the master password or DEK) so a second device can pre-fill the
+ * login form by scanning a QR code. The user must still enter their master
+ * password on the new device — the zero-knowledge model is preserved.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  encodePairPayload,
+  decodePairPayload,
+  buildPairUrl,
+  parsePairUrl,
+  PAIR_QUERY_PARAM,
+  PairPayloadError,
+  type PairPayload,
+} from "./deviceSync";
+
+const SAMPLE: PairPayload = {
+  v: 1,
+  apiBaseUrl: "https://cardpulse-api.fly.dev",
+  email: "user@example.com",
+};
+
+describe("encodePairPayload / decodePairPayload", () => {
+  it("round-trips a valid payload", () => {
+    const encoded = encodePairPayload(SAMPLE);
+    const decoded = decodePairPayload(encoded);
+    expect(decoded).toEqual(SAMPLE);
+  });
+
+  it("produces a URL-safe string with no padding", () => {
+    const encoded = encodePairPayload(SAMPLE);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+  });
+
+  it("handles unicode emails", () => {
+    const payload: PairPayload = {
+      v: 1,
+      apiBaseUrl: "https://example.test",
+      email: "usuário@exemplo.com.br",
+    };
+    expect(decodePairPayload(encodePairPayload(payload))).toEqual(payload);
+  });
+
+  it("throws PairPayloadError on malformed base64url input", () => {
+    expect(() => decodePairPayload("not-valid-base64!!!")).toThrow(
+      PairPayloadError,
+    );
+  });
+
+  it("throws PairPayloadError on non-JSON content", () => {
+    // base64url("hello") = "aGVsbG8"
+    expect(() => decodePairPayload("aGVsbG8")).toThrow(PairPayloadError);
+  });
+
+  it("throws PairPayloadError when version is missing", () => {
+    const bad = encodePairPayload({
+      ...SAMPLE,
+      // @ts-expect-error — intentionally invalid for the test
+      v: undefined,
+    });
+    expect(() => decodePairPayload(bad)).toThrow(PairPayloadError);
+  });
+
+  it("throws PairPayloadError on unsupported version", () => {
+    const bad = encodePairPayload({ ...SAMPLE, v: 99 as 1 });
+    expect(() => decodePairPayload(bad)).toThrow(PairPayloadError);
+  });
+
+  it("throws PairPayloadError when apiBaseUrl is missing", () => {
+    const bad = encodePairPayload({
+      ...SAMPLE,
+      // @ts-expect-error — intentionally invalid for the test
+      apiBaseUrl: undefined,
+    });
+    expect(() => decodePairPayload(bad)).toThrow(PairPayloadError);
+  });
+
+  it("throws PairPayloadError when email is missing", () => {
+    const bad = encodePairPayload({
+      ...SAMPLE,
+      // @ts-expect-error — intentionally invalid for the test
+      email: undefined,
+    });
+    expect(() => decodePairPayload(bad)).toThrow(PairPayloadError);
+  });
+
+  it("rejects payloads with non-http(s) URLs", () => {
+    const bad = encodePairPayload({
+      ...SAMPLE,
+      apiBaseUrl: "javascript:alert(1)",
+    });
+    expect(() => decodePairPayload(bad)).toThrow(PairPayloadError);
+  });
+
+  it("never includes a master password field", () => {
+    const encoded = encodePairPayload(SAMPLE);
+    const json = atob(
+      encoded.replace(/-/g, "+").replace(/_/g, "/") +
+        "==".slice(0, (4 - (encoded.length % 4)) % 4),
+    );
+    expect(json).not.toMatch(/password/i);
+    expect(json).not.toMatch(/dek/i);
+    expect(json).not.toMatch(/master/i);
+  });
+});
+
+describe("buildPairUrl / parsePairUrl", () => {
+  it("appends the encoded payload as a query param", () => {
+    const url = buildPairUrl("https://app.example.com/login", SAMPLE);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get(PAIR_QUERY_PARAM)).toBe(
+      encodePairPayload(SAMPLE),
+    );
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://app.example.com/login",
+    );
+  });
+
+  it("preserves an existing query string on the dashboard URL", () => {
+    const url = buildPairUrl("https://app.example.com/?utm=email", SAMPLE);
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("utm")).toBe("email");
+    expect(parsed.searchParams.get(PAIR_QUERY_PARAM)).not.toBeNull();
+  });
+
+  it("parses a valid pair URL into a payload", () => {
+    const url = buildPairUrl("https://app.example.com/", SAMPLE);
+    expect(parsePairUrl(url)).toEqual(SAMPLE);
+  });
+
+  it("returns null for a URL without the pair param", () => {
+    expect(parsePairUrl("https://app.example.com/")).toBeNull();
+  });
+
+  it("accepts a query string fragment", () => {
+    const encoded = encodePairPayload(SAMPLE);
+    expect(parsePairUrl(`?${PAIR_QUERY_PARAM}=${encoded}`)).toEqual(SAMPLE);
+  });
+
+  it("returns null when the param value is malformed", () => {
+    expect(parsePairUrl(`?${PAIR_QUERY_PARAM}=garbage!!!`)).toBeNull();
+  });
+});

--- a/dashboard/src/lib/deviceSync.ts
+++ b/dashboard/src/lib/deviceSync.ts
@@ -1,0 +1,203 @@
+/**
+ * Multi-device pairing helpers.
+ *
+ * CardPulse's zero-knowledge model already supports multi-device usage out
+ * of the box: the wrapped DEK is stored on the server, so any device with
+ * the user's email + master password can log in and decrypt their data.
+ *
+ * This module adds an optional convenience layer: the source device can
+ * generate a "pair payload" containing the API base URL and email (NEVER
+ * the master password or DEK). The payload is encoded as a base64url JSON
+ * blob, attached to a dashboard URL via the `pair` query parameter, and
+ * rendered as a QR code. The destination device scans the code, opens the
+ * URL, and the login form pre-fills the API URL + email — the user only
+ * needs to type their master password.
+ *
+ * The master password never leaves the user's head, so the security model
+ * is unchanged.
+ */
+
+/** Query parameter name used in pair URLs. */
+export const PAIR_QUERY_PARAM = "pair";
+
+/** Current schema version for forward compatibility. */
+export const PAIR_PAYLOAD_VERSION = 1 as const;
+
+/**
+ * Pairing payload encoded into the QR code.
+ *
+ * Intentionally limited to non-secret fields. Adding a master password
+ * or DEK here would break the zero-knowledge guarantee.
+ */
+export interface PairPayload {
+  /** Schema version. Always {@link PAIR_PAYLOAD_VERSION}. */
+  v: typeof PAIR_PAYLOAD_VERSION;
+  /** API base URL the destination device should talk to. */
+  apiBaseUrl: string;
+  /** Account email to pre-fill in the login form. */
+  email: string;
+}
+
+/** Thrown when a pair payload fails to decode or validate. */
+export class PairPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PairPayloadError";
+  }
+}
+
+// ── base64url helpers ────────────────────────────────────────────────────────
+
+/** Encodes a UTF-8 string into base64url (no padding, URL-safe alphabet). */
+function toBase64Url(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+/** Decodes a base64url string back into a UTF-8 string. */
+function fromBase64Url(input: string): string {
+  // Reject any character outside the base64url alphabet up front so callers
+  // get a deterministic error instead of relying on `atob`'s lenient parser.
+  if (!/^[A-Za-z0-9_-]*$/.test(input)) {
+    throw new PairPayloadError("Pair payload contains invalid characters");
+  }
+  const padded =
+    input.replace(/-/g, "+").replace(/_/g, "/") +
+    "==".slice(0, (4 - (input.length % 4)) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new PairPayloadError("Pair payload is not valid base64url");
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+// ── Encode / decode ─────────────────────────────────────────────────────────
+
+/**
+ * Validates a payload shape and returns it as a {@link PairPayload}.
+ *
+ * @throws {PairPayloadError} if any required field is missing or invalid.
+ */
+function validatePayload(value: unknown): PairPayload {
+  if (typeof value !== "object" || value === null) {
+    throw new PairPayloadError("Pair payload is not an object");
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj.v !== PAIR_PAYLOAD_VERSION) {
+    throw new PairPayloadError(
+      `Unsupported pair payload version: ${String(obj.v)}`,
+    );
+  }
+  if (typeof obj.apiBaseUrl !== "string" || obj.apiBaseUrl.length === 0) {
+    throw new PairPayloadError("Pair payload is missing apiBaseUrl");
+  }
+  if (typeof obj.email !== "string" || obj.email.length === 0) {
+    throw new PairPayloadError("Pair payload is missing email");
+  }
+  // Defense in depth: refuse anything that doesn't parse as http(s).
+  let parsed: URL;
+  try {
+    parsed = new URL(obj.apiBaseUrl);
+  } catch {
+    throw new PairPayloadError("Pair payload apiBaseUrl is not a valid URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new PairPayloadError(
+      "Pair payload apiBaseUrl must use http or https",
+    );
+  }
+  return {
+    v: PAIR_PAYLOAD_VERSION,
+    apiBaseUrl: obj.apiBaseUrl,
+    email: obj.email,
+  };
+}
+
+/** Encodes a payload as a base64url JSON string. */
+export function encodePairPayload(payload: PairPayload): string {
+  // We deliberately do NOT validate on encode — call sites occasionally
+  // need to construct intentionally malformed payloads (e.g. tests).
+  // Decode is the canonical validation boundary.
+  return toBase64Url(JSON.stringify(payload));
+}
+
+/**
+ * Decodes a base64url JSON string back into a {@link PairPayload}.
+ *
+ * @throws {PairPayloadError} if the input cannot be decoded or fails
+ *   structural validation.
+ */
+export function decodePairPayload(encoded: string): PairPayload {
+  let json: string;
+  try {
+    json = fromBase64Url(encoded);
+  } catch (error) {
+    if (error instanceof PairPayloadError) throw error;
+    throw new PairPayloadError("Pair payload could not be decoded");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new PairPayloadError("Pair payload is not valid JSON");
+  }
+  return validatePayload(parsed);
+}
+
+// ── URL helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns a dashboard URL with the encoded payload appended as a query
+ * parameter, preserving any existing query string.
+ */
+export function buildPairUrl(dashboardUrl: string, payload: PairPayload): string {
+  // Use a permissive base so callers can pass either an absolute URL or a
+  // relative path.
+  const url = new URL(dashboardUrl, "https://placeholder.invalid");
+  url.searchParams.set(PAIR_QUERY_PARAM, encodePairPayload(payload));
+  if (url.hostname === "placeholder.invalid") {
+    return url.pathname + url.search + url.hash;
+  }
+  return url.toString();
+}
+
+/**
+ * Extracts and decodes a pair payload from a URL or query string.
+ *
+ * Returns `null` if the input has no `pair` parameter or if the payload
+ * fails to decode. Errors are intentionally swallowed here so callers can
+ * fall through to a normal login flow when scanning a stale or
+ * tampered-with QR.
+ */
+export function parsePairUrl(input: string): PairPayload | null {
+  let params: URLSearchParams;
+  try {
+    if (input.startsWith("?")) {
+      params = new URLSearchParams(input);
+    } else {
+      params = new URL(input, "https://placeholder.invalid").searchParams;
+    }
+  } catch {
+    return null;
+  }
+  const encoded = params.get(PAIR_QUERY_PARAM);
+  if (!encoded) return null;
+  try {
+    return decodePairPayload(encoded);
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/src/lib/session.ts
+++ b/dashboard/src/lib/session.ts
@@ -16,6 +16,14 @@ export interface Session {
   readonly dekSalt: string;
   readonly dekParams: DekParams;
   readonly dek: Uint8Array | null;
+  /**
+   * Account email captured at login time.
+   *
+   * Stored only in memory (cleared on refresh / logout) and exposed
+   * exclusively for UX features such as the multi-device pair QR code.
+   * Never persisted alongside any secret material.
+   */
+  readonly email: string | null;
 }
 
 /** Input for creating a new session after login. */
@@ -25,6 +33,7 @@ export interface SessionInput {
   dekSalt: string;
   dekParams: DekParams;
   dek?: Uint8Array;
+  email?: string;
 }
 
 // ── Private state ────────────────────────────────────────────────────────────
@@ -71,6 +80,7 @@ export function setSession(input: SessionInput): void {
     dekSalt: input.dekSalt,
     dekParams: input.dekParams,
     dek: input.dek ?? null,
+    email: input.email ?? null,
   };
   notifyListeners();
 }

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -15,13 +15,26 @@ import { deriveKey, unwrapDek, CryptoError } from "../lib/crypto";
 import type { DekParams } from "../lib/crypto";
 import { useAuth } from "../hooks/useAuth";
 import type { LoginResponse } from "../types/api";
+import { parsePairUrl } from "../lib/deviceSync";
 
 /** State for the two-step login flow. */
 type LoginStep = "credentials" | "master-password";
 
+/**
+ * Reads an optional pair payload from the current URL so a freshly-paired
+ * device can pre-fill the email field. Returns an empty string when there
+ * is no payload, the payload is malformed, or the page is rendered in a
+ * non-browser environment (e.g. SSR / tests).
+ */
+function readPairedEmail(): string {
+  if (typeof window === "undefined") return "";
+  const payload = parsePairUrl(window.location.href);
+  return payload?.email ?? "";
+}
+
 export function LoginPage() {
   const [step, setStep] = useState<LoginStep>("credentials");
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(() => readPairedEmail());
   const [password, setPassword] = useState("");
   const [masterPassword, setMasterPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -46,12 +59,15 @@ export function LoginPage() {
           ? JSON.parse(data.dek_params)
           : data.dek_params;
 
-      // Store session (JWT + wrapped DEK data) in memory
+      // Store session (JWT + wrapped DEK data + email) in memory.
+      // Email is captured here so the multi-device pair QR can later
+      // pre-fill it on a second device — never persisted to disk.
       login({
         token: data.token,
         wrappedDek: data.wrapped_dek,
         dekSalt: data.dek_salt,
         dekParams,
+        email,
       });
 
       setLoginData(data);


### PR DESCRIPTION
## Summary
- Adds an opt-in QR-based device pairing flow on top of CardPulse's existing zero-knowledge multi-device support (the wrapped DEK is already on the server, so any client with the email + master password can derive the DEK locally).
- New `lib/deviceSync.ts` encodes/decodes a versioned base64url JSON pair payload containing only the API base URL and email — never the master password or DEK — with strict schema validation and an `http(s)` allow-list.
- New `DeviceSyncModal` renders a QR code (via the `qrcode` package) and a copyable pair link, accessible from the layout header via a new **Sync device** button (visible only when the session is unlocked).
- `LoginPage` reads the optional `?pair=` query parameter on the destination device and pre-fills the email field; malformed payloads fall through to the normal login.
- `Session` now carries the email captured at login time so the QR can be generated without re-prompting; email is in-memory only.
- README.md gains a new **Multi-Device Sync** section documenting both the manual and QR-based flows for the dashboard and Scriptable, plus a security checklist and a Mermaid diagram of the key derivation invariant.

## Test plan
- [x] `npm run lint` clean
- [x] `npx vitest run` — 302/302 tests pass (17 new in `deviceSync.test.ts` covering round-trip, schema validation, malformed input, URL build/parse, and the zero-knowledge invariant that the encoded payload never contains the strings ``password``, ``dek``, or ``master``)
- [x] `npm run build` succeeds
- [ ] Manual: open dashboard → click **Sync device** → confirm a QR renders with the current email
- [ ] Manual: scan the QR (or open the copied link) on a second browser/device → confirm the email is pre-filled on the login form
- [ ] Manual: log in on the second device with the master password → confirm the same data decrypts
- [ ] Manual: open `?pair=garbage` → confirm login still works without errors

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)